### PR TITLE
CI: add publish_release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine build
+          pip install --upgrade setuptools wheel twine build poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Get release notes
         id: release_notes

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,57 @@
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching `v*` version srings. e.g. v1.0, v20.15.10
+
+name: Create and Publish Release
+
+jobs:
+  build:
+    name: Create and Publish Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine build
+
+      - name: Get release notes
+        id: release_notes
+        run: |
+          # By default, GH Actions checkout will only fetch a single commit.
+          # For us to extract the release notes, we need to fetch the tags
+          # and tag annotations as well.
+          # https://github.com/actions/checkout/issues/290
+          git fetch --tags --force
+          TAG_NAME=${GITHUB_REF/refs\/tags\//}
+          echo "$(git tag -l --format='%(contents)' $TAG_NAME)" > "${{ runner.temp }}/CHANGELOG.md"
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: "${{ runner.temp }}/CHANGELOG.md"
+          draft: false
+          prerelease: false
+
+      - name: Build and publish to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m build
+          twine upload dist/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,4 +55,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m build
-          twine upload dist/*
+          twine upload -r testpypi dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
 name = "diffenator2"
 description = "Compare two fonts"
-version = "0.0.1"
 authors = [ "Marc Foley <m.foley.88@gmail.com>" ]
+version = "0"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+source = "git-tag"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
@@ -22,8 +26,8 @@ tqdm = "^4.64.1"
 youseedee = "^0.3.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.scripts]
 _diffbrowsers = 'diffenator2._diffbrowsers:main'


### PR DESCRIPTION
This PR finally adds the ability to publish a release to pypi. Dynamic versioning is handled by the fab plugin, https://github.com/tiangolo/poetry-version-plugin. 

Still testing this at the moment so releases are being pushed to the pypi test area. If I'm happy with it, I'll send em to prod.