### PR TITLE
scale_upem takes a new upem

### DIFF
--- a/src/diffenator2/font.py
+++ b/src/diffenator2/font.py
@@ -71,10 +71,8 @@ def match_fonts(
     logger.info(
         f"Matching {os.path.basename(old_font.path)} to {os.path.basename(new_font.path)}"
     )
-    if scale_upm:
-        ratio = new_font.ttFont["head"].unitsPerEm / old_font.ttFont["head"].unitsPerEm
-        if ratio != 1.0:
-            scale_upem(old_font.ttFont, ratio)
+    if scale_upm and new_font.ttFont["head"].unitsPerEm != old_font.ttFont["head"].unitsPerEm:
+        scale_upem(old_font.ttFont, new_font.ttFont["head"].unitsPerEm)
 
     if variations and old_font.is_variable() and new_font.is_variable():
         old_font.set_variations(variations)


### PR DESCRIPTION
fontTools.ttLib.scale_upem takes a new UPEM value:

```
def scale_upem(font, new_upem):
```

But we feed it a ratio:

```
        ratio = new_font.ttFont["head"].unitsPerEm / old_font.ttFont["head"].unitsPerEm
        if ratio != 1.0:
            scale_upem(old_font.ttFont, ratio)
```

This means that old_font's UPEM generally ends up around zero, and everything goes wrong afterwards.

Found while debugging something else...