### PR TITLE
Use font metrics when renderering

### DIFF
--- a/src/diffenator2/renderer.py
+++ b/src/diffenator2/renderer.py
@@ -68,14 +68,16 @@ class Renderer:
         infos = buf.glyph_infos
         positions = buf.glyph_positions
         glyphLine = buildGlyphLine(infos, positions, glyphNames)
-        bounds = calcGlyphLineBounds(glyphLine, font)
+        orig_bounds = calcGlyphLineBounds(glyphLine, font)
+        extents = self.font.hbFont.get_font_extents(buf.direction)
+        bounds = (0, extents.descender, orig_bounds[2], extents.ascender)
         bounds = scaleRect(bounds, scaleFactor, scaleFactor)
         bounds = insetRect(bounds, -self.margin, -self.margin)
         bounds = intRect(bounds)
         surfaceClass = getSurfaceClass("skia", ".png")
 
         surface = surfaceClass()
-        if bounds[2] == 0 and bounds[3] == 0:
+        if orig_bounds[2] == 0 and orig_bounds[3] ==0:
             return Image.new("RGBA", (0,0))
         with surface.canvas(bounds) as canvas:
             canvas.scale(scaleFactor)

--- a/src/diffenator2/renderer.py
+++ b/src/diffenator2/renderer.py
@@ -16,6 +16,7 @@ import numpy as np
 import freetype as ft
 from dataclasses import dataclass, field
 
+FONT_SIZE = 28
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ class PixelDiffer:
     def __post_init__(self):
         self.renderer_a = Renderer(
             self.font_a,
-            font_size=28,
+            font_size=FONT_SIZE,
             margin=0,
             features=self.features,
             script=self.script,
@@ -178,7 +179,7 @@ class PixelDiffer:
         )
         self.renderer_b = Renderer(
             self.font_b,
-            font_size=28,
+            font_size=FONT_SIZE,
             margin=0,
             features=self.features,
             script=self.script,


### PR DESCRIPTION
Diffenator was giving false negatives and false positives when comparing fonts with different vertical metrics. This is because the renderered images had different baselines, and when we subtracted one from the other, we got 'ghosting'.
![diff](https://user-images.githubusercontent.com/106728/222714802-424be7da-d7f5-419c-ab6f-6375696d4e30.png)

This uses harfbuzz to get font extents (because HB applies MVAR variations for us), making the baselines line up.