### PR TITLE
Fix crash with left-hanging glyphs

### DIFF
--- a/src/diffenator2/renderer.py
+++ b/src/diffenator2/renderer.py
@@ -70,7 +70,7 @@ class Renderer:
         glyphLine = buildGlyphLine(infos, positions, glyphNames)
         orig_bounds = calcGlyphLineBounds(glyphLine, font)
         extents = self.font.hbFont.get_font_extents(buf.direction)
-        bounds = (0, extents.descender, orig_bounds[2], extents.ascender)
+        bounds = (orig_bounds[0], extents.descender, orig_bounds[2], extents.ascender)
         bounds = scaleRect(bounds, scaleFactor, scaleFactor)
         bounds = insetRect(bounds, -self.margin, -self.margin)
         bounds = intRect(bounds)


### PR DESCRIPTION
I was getting crashes with some regression tests; if a glyph hangs over to the left, we want to maintain the negative X coordinate, or else the right edge can be less than the left edge, and that makes Skia crash.