### PR TITLE
render: calculate canvas bounds correctly

### DIFF
--- a/src/diffenator2/renderer.py
+++ b/src/diffenator2/renderer.py
@@ -70,14 +70,23 @@ class Renderer:
         glyphLine = buildGlyphLine(infos, positions, glyphNames)
         orig_bounds = calcGlyphLineBounds(glyphLine, font)
         extents = self.font.hbFont.get_font_extents(buf.direction)
-        bounds = (orig_bounds[0], extents.descender, orig_bounds[2], extents.ascender)
+        # bounds is a tuple defined as (xMin, yMin, xMax, yMax)
+        bounds = (
+            min(orig_bounds[0], orig_bounds[2]),
+            min(extents.descender, extents.ascender),
+            max(orig_bounds[0], orig_bounds[2]),
+            max(extents.descender, extents.ascender),
+        )
         bounds = scaleRect(bounds, scaleFactor, scaleFactor)
         bounds = insetRect(bounds, -self.margin, -self.margin)
         bounds = intRect(bounds)
         surfaceClass = getSurfaceClass("skia", ".png")
 
         surface = surfaceClass()
-        if orig_bounds[2] == 0 and orig_bounds[3] ==0:
+        # return empty canvas if either width or height == 0. Not doing so
+        # causes Skia to raise a null pointer error
+        if orig_bounds[0] == orig_bounds[2] or \
+            orig_bounds[1] == orig_bounds[3]:
             return Image.new("RGBA", (0,0))
         with surface.canvas(bounds) as canvas:
             canvas.scale(scaleFactor)


### PR DESCRIPTION
I noticed diffenator2 is failing in https://github.com/google/fonts/actions/runs/4416701337/jobs/7742863066#step:6:2394. It's failing because Skia is attempting to create a canvas by using an incorrectly defined bounding box variable. Bounds are defined as a tuple `(xMin, yMin, xMax, yMax)`. Currently, our bounds tuple could have negative xMax or yMax values which isn't correct (you occasionally get negative values for glyphs such as combining marks).