### PR TITLE
diffbrowsers: add proofing page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = ">=3.7,<4.0"
 fontTools = { version = ">=4.37.3", extras = ["ufo"] }
 jinja2 = "*"
 Pillow = "*"
+glyphsets = "*"
 uharfbuzz = "*"
 pyahocorasick = "*"
 selenium = ">=4.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.7,<4.0"
 fontTools = { version = ">=4.37.3", extras = ["ufo"] }
 jinja2 = "*"
 Pillow = "*"
-glyphsets = "*"
+glyphsets = ">=0.6.0"
 uharfbuzz = "*"
 pyahocorasick = "*"
 selenium = ">=4.4.3"

--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -96,7 +96,9 @@ def ninja_diff(
             pt_size,
         )
         return
-    styles = styles_in_fonts(fonts_before)
+    styles_before = styles_in_fonts(fonts_before)
+    styles_after = [style for _, style, _ in styles_in_fonts(fonts_after)]
+    styles = [s for s in styles_before if s[1] in styles_after]
     partitioned = partition(styles, MAX_STYLES)
     if not os.path.exists(out):
         os.mkdir(out)

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -7,6 +7,7 @@ import os
 import shutil
 from diffenator2.template_elements import CSSFontStyle, CSSFontFace
 from diffenator2.utils import font_sample_text
+from glyphsets import GFTestData
 import re
 
 
@@ -85,6 +86,7 @@ def proof_rendering(ttFonts, templates, dst="out", filter_styles=None, pt_size=2
     font_faces = [CSSFontFace(f) for f in ttFonts]
     font_styles = get_font_styles(ttFonts, filters=filter_styles)
     sample_text = " ".join(font_sample_text(ttFonts[0]))
+    test_strings = GFTestData.test_strings_in_font(ttFonts[0])
     glyphs = [chr(c) for c in ttFonts[0].getBestCmap()]
     _package(
         templates,
@@ -93,6 +95,7 @@ def proof_rendering(ttFonts, templates, dst="out", filter_styles=None, pt_size=2
         font_styles=font_styles,
         sample_text=sample_text,
         glyphs=glyphs,
+        test_strings=test_strings,
         pt_size=pt_size,
     )
 

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -110,6 +110,7 @@ def diff_rendering(ttFonts_old, ttFonts_new, templates, dst="out", filter_styles
     font_styles_old, font_styles_new = _match_styles(font_styles_old, font_styles_new)
 
     sample_text = " ".join(font_sample_text(ttFonts_old[0]))
+    test_strings = GFTestData.test_strings_in_font(ttFonts_old[0])
     glyphs = [chr(c) for c in ttFonts_old[0].getBestCmap()]
     _package(
         templates,
@@ -121,6 +122,7 @@ def diff_rendering(ttFonts_old, ttFonts_new, templates, dst="out", filter_styles
         include_ui=True,
         sample_text=sample_text,
         glyphs=glyphs,
+        test_strings=test_strings,
         pt_size=pt_size,
     )
 

--- a/src/diffenator2/screenshot.py
+++ b/src/diffenator2/screenshot.py
@@ -111,14 +111,18 @@ class ScreenShotter:
             browser.quit()
 
 
-def screenshot_dir(dir_fp: str, out: str):
+def screenshot_dir(
+        dir_fp: str,
+        out: str,
+        skip=["diffbrowsers_proofer.html", "diffenator.html"],
+):
     """Screenshot a folder of html docs. Walk the damn things"""
     if not os.path.exists(out):
         os.mkdir(out)
     screenshotter = ScreenShotter()
     for dirpath, _, filenames in os.walk(dir_fp):
         for filename in filenames:
-            if not filename.endswith(".html") or "diffenator" in filename:
+            if not filename.endswith(".html") or filename in skip:
                 continue
             fp = os.path.join(dirpath, filename)
             fp = os.path.abspath(fp)

--- a/src/diffenator2/shape.py
+++ b/src/diffenator2/shape.py
@@ -83,7 +83,7 @@ def test_font_glyphs(font_a, font_b):
     for g in same_glyphs:
         pc, diff_map = differ.diff(g)
         if pc > THRESHOLD:
-            glyph = GlyphDiff(g, pc, diff_map)
+            glyph = GlyphDiff(g, "%.2f" % pc, diff_map)
             modified_glyphs.append(glyph)
     modified_glyphs.sort(key=lambda k: k.changed_pixels, reverse=True)
 

--- a/src/diffenator2/template_elements.py
+++ b/src/diffenator2/template_elements.py
@@ -52,7 +52,7 @@ class Glyph(Renderable):
 @dataclass
 class GlyphDiff(Renderable):
     string: str
-    changed_pixels: float
+    changed_pixels: str
     diff_map: list[int]
     name: str=None
     unicode: str=None

--- a/src/diffenator2/template_elements.py
+++ b/src/diffenator2/template_elements.py
@@ -82,11 +82,11 @@ class CSSFontStyle(Renderable):
         if self.suffix:
             self.cssfamilyname = f"{self.suffix} {self.familyname}"
             self.class_name = (
-                f"{self.suffix} {self.familyname} {self.stylename}".replace(" ", "-")
+                f"{self.suffix} {self.stylename}".replace(" ", "-")
             )
         else:
             self.cssfamilyname = self.familyname
-            self.class_name = f"{self.familyname} {self.stylename}".replace(" ", "-")
+            self.class_name = f"{self.stylename}".replace(" ", "-")
 
 
 @dataclass

--- a/src/diffenator2/templates/GlyphDiff.partial.html
+++ b/src/diffenator2/templates/GlyphDiff.partial.html
@@ -5,9 +5,6 @@
             name: {{ name }}<br>
             unicode: {{ unicode }}<br>
             changed pixels: {{ changed_pixels }}%
-            <div>
-                diff map: {{ diff_map }}
-            </div>
         </span>
     </div>
 </div>

--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -35,19 +35,21 @@
 	  z-index: 100;
 	}
 	#font-toggle{
-	  display: block;
-	  font-weight: 700;
-	  cursor: pointer;
-	  -webkit-user-select: none; /* Safari */        
-	  -moz-user-select: none; /* Firefox */
-          -ms-user-select: none; /* IE10+/Edge */
-	  user-select: none; /* Standard */
-	  text-align: center;
-	  color: white;
-	  background-color: black;
-	  width: 50px;
-	  display: block;
-	  padding: 10px;
+	}
+	.nav-item{
+		display: block;
+		cursor: pointer;
+		-webkit-user-select: none; /* Safari */        
+		-moz-user-select: none; /* Firefox */
+			-ms-user-select: none; /* IE10+/Edge */
+		user-select: none; /* Standard */
+		text-align: center;
+		color: white;
+		background-color: black;
+		display: block;
+		font-size: 9pt;
+		padding: 5px;
+		margin: 2px;
 	}
 	.tooltip {
 	position: relative;
@@ -163,7 +165,8 @@
 <body>
     {% if include_ui %}
     <div id="nav">
-        <div id="font-toggle">old</div>
+        <div class="nav-item" id="font-toggle">old</div>
+		{% block nav %}{% endblock %}
      </div>
     {% endif %}
     <div id="content">
@@ -184,7 +187,7 @@
 	  POSITION = "new"
 	  for (item of items) {
 	    item.firstElementChild.textContent = item.firstElementChild.textContent.replace("old", "new")
-            item.lastElementChild.className = item.lastElementChild.className.replace("old", "new")
+		item.lastElementChild.className = item.lastElementChild.className.replace("old", "new")
 	    fontToggle.textContent = "new"
 	  }
 
@@ -192,7 +195,7 @@
 	  POSITION = "old"
 	  for (item of items) {
 	    item.firstElementChild.textContent = item.firstElementChild.textContent.replace("new", "old")
-            item.lastElementChild.className = item.lastElementChild.className.replace("new", "old")
+		item.lastElementChild.className = item.lastElementChild.className.replace("new", "old")
 	    fontToggle.textContent = "old"
 	  }
 	}

--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -12,7 +12,6 @@
 	}
 	.box-title{
 	  width: 100%;
-	  float: left;
 	  font-size: 8pt;
 	  font-weight: 700;
 	  border-top: 1px solid black;

--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -26,7 +26,6 @@
 	  float: left;
 	}
 	.box-text{
-		float: left;
 	}
 	
 	#nav{
@@ -180,23 +179,27 @@
 	POSITION = "old"
 	fontToggle = document.getElementById("font-toggle")
 	function switchFonts() {
-	  items = document.getElementsByClassName("box");
-	  console.log("Click from "+POSITION)
+	boxTitles = document.getElementsByClassName("box-title")
+	items = document.getElementsByClassName("box-text");
 	  
-	  if (POSITION === "old") {
+	if (POSITION === "old") {
 	  POSITION = "new"
-	  for (item of items) {
-	    item.firstElementChild.textContent = item.firstElementChild.textContent.replace("old", "new")
-		item.lastElementChild.className = item.lastElementChild.className.replace("old", "new")
+	  for (item of boxTitles) {
+	    item.textContent = item.textContent.replace("old", "new")
 	    fontToggle.textContent = "new"
+	  }
+	  for (item of items) {
+		item.className = item.className.replace("old", "new")
 	  }
 
 	  } else {
 	  POSITION = "old"
-	  for (item of items) {
-	    item.firstElementChild.textContent = item.firstElementChild.textContent.replace("new", "old")
-		item.lastElementChild.className = item.lastElementChild.className.replace("new", "old")
+	  for (item of boxTitles) {
+	    item.textContent = item.textContent.replace("new", "old")
 	    fontToggle.textContent = "old"
+	  }
+	  for (item of items) {
+		item.className = item.className.replace("new", "old")
 	  }
 	}
 	}

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -128,6 +128,7 @@ function viewMode() {
         document.getElementById("font-by-font").style.display = "none"
         document.getElementById("side-by-side").style.display = "block"
         state = "side-by-side"
+        setWidth()
         viewButton.innerHTML = "Side by side"
     } else if (state === "side-by-side") {
         document.getElementById("line-by-line").style.display = "block"
@@ -147,7 +148,7 @@ document.getElementById("view-button").addEventListener("click", viewMode)
             var textBox = textBoxes[i]
             textBox.style.fontSize = newPtSize
         }
-
+        setWidth()
     })
 
 // break text for side by side view
@@ -235,6 +236,44 @@ for (jj=0; jj<currentText.length; jj++) {
     }
 }
 node.innerHTML = newText
+}
+
+function longestLine() {
+    var paragraphs = document.getElementsByClassName("texty")
+    var res = 0
+    for (i=0; i<paragraphs.length; i++) {
+        var cur = lineLength(paragraphs[i])
+        res = Math.max(cur, res)
+    }
+    return res
+}
+
+function lineLength(elem) {
+    var node = grabTextNodes(elem)[0]
+    var range = document.createRange()
+    var width = 0
+    for (j=1; j<=node.textContent.length; j++) {
+        var p = j - 1
+        range.setStart(node, p)
+        range.setEnd(node, j)
+        width += range.getBoundingClientRect().width
+    }
+    return width
+}
+
+function setWidth() {
+    var width = longestLine()
+    var container = document.getElementById("side-by-side")
+    var subContainers = container.getElementsByClassName("box-side-by-side")
+    
+    var containerWidth = (width * subContainers.length) + 100
+    container.style.width = containerWidth + "pt"
+
+    for (i=0; i<subContainers.length; i++) {
+        subContainer = subContainers[i]
+        var dist = Math.ceil(width) + "pt"
+        subContainer.style.maxWidth = dist
+    }
 }
 
 

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -1,24 +1,114 @@
 {% extends "_base.html" %}
 {% block title %}Proofer{% endblock %}
+{% block style %}
+{{ super() }}
+#toolbar {
+    float:right;
+    position: fixed;
+    right: 20px;
+    top: 20px;
+    cursor: default;
+    user-select: none; /* Standard */
+    border: 1px solid black;
+    font-size: 9pt;
+}
+#toggle {
+    padding: 5px;
+    color: white;
+    background-color: black;
+
+}
+#pt-dropdown {
+    padding: 5px;
+    background-color: white;
+}
+{% endblock %}
 
 {% block content_name %}
 <b>Proofer</b>
 {% endblock %}
 {% block content %}
-    {% for glyph_set, section in test_strings.items() %}
+<div id="toolbar">
+    <div id="toggle">
+        Line by line
+    </div>
+    <div id="pt-dropdown">
+        <label for="pt-size">Font Size:</label>
+            <select id="pt-selector" name="pt">
+            <option value="10pt">10pt</option>
+            <option selected="selected" value="{{ pt_size }}pt">{{ pt_size }}pt</option>
+            <option value="48pt">48pt</option>
+            <option value="96pt">96pt</option>
+        </select>
+    </div>
+</div>
+
+    <div id="family-grouped">
+        {% for glyph_set, section in test_strings.items() %}
         <h3>Glyphset: {{ glyph_set }}</h3>
         {% for section_title, strings in section.items() %}
             <div class="box">
             <div class="box-title">{{ section_title }}</div>
             {% for string in strings %}
             {% for font_class in font_styles or font_styles_old or font_styles_new %}
-                <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+                <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">
                     {{ string }}<br>
-                </span>
+                </div>
             {% endfor %}
             <br>
             {% endfor %}
         </div>
         {% endfor %}
     {% endfor %}
+    </div>
+
+    <div id="side-grouped">
+        {% for glyph_set, section in test_strings.items() %}
+        <h3>Glyphset: {{ glyph_set }}</h3>
+        {% for font_class in font_styles or font_styles_old or font_styles_new %}
+        <div class="box-title">{{ font_class.class_name }} {{ pt_size }}pt</div>
+        {% for section_title, strings in section.items() %}
+            <div class="box">
+            <div class="box-title">{{ section_title }}</div>
+            {% for string in strings %}
+                <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">
+                    {{ string }}<br>
+                </div>
+            {% endfor %}
+            <br>
+            {% endfor %}
+        </div>
+        {% endfor %}
+    {% endfor %} 
+    </div>
+
+    <script>
+        visible = true
+        function toggleGroup() {
+            var toggle = document.getElementById("toggle")
+            if (visible === true) {
+                document.getElementById("family-grouped").style.display = "none"
+                document.getElementById("side-grouped").style.display = "block"
+                visible = false
+                toggle.innerHTML = "Fonts stacked"
+            } else {
+                document.getElementById("family-grouped").style.display = "block"
+                document.getElementById("side-grouped").style.display = "none"
+                visible = true
+                toggle.innerHTML = "Line by line"
+            }
+        }
+        document.getElementById("toggle").addEventListener("click", toggleGroup)
+        
+        var ptSelector = document.getElementById("pt-selector");
+        ptSelector.addEventListener("change", function(e) {
+            var newPtSize = e.target.value
+            textBoxes = document.getElementsByClassName("texty")
+            for (i=0; i<textBoxes.length; i++) {
+                var textBox = textBoxes[i]
+                textBox.style.fontSize = newPtSize
+            }
+
+        })
+    </script>
 {% endblock %}

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -12,7 +12,7 @@
     border: 1px solid black;
     font-size: 9pt;
 }
-#toggle {
+#view-button {
     padding: 5px;
     color: white;
     background-color: black;
@@ -22,6 +22,15 @@
     padding: 5px;
     background-color: white;
 }
+#side-by-side {
+    width: 6000px;
+}
+.box-side-by-side {
+    word-break: break-all;
+    float: left;
+    min-width: 200px;
+    max-width: 500px;
+}
 {% endblock %}
 
 {% block content_name %}
@@ -29,7 +38,7 @@
 {% endblock %}
 {% block content %}
 <div id="toolbar">
-    <div id="toggle">
+    <div id="view-button">
         Line by line
     </div>
     <div id="pt-dropdown">
@@ -43,7 +52,7 @@
     </div>
 </div>
 
-    <div id="family-grouped">
+<div id="line-by-line" style="display: block;">
         {% for glyph_set, section in test_strings.items() %}
         <h3>Glyphset: {{ glyph_set }}</h3>
         {% for section_title, strings in section.items() %}
@@ -62,53 +71,171 @@
     {% endfor %}
     </div>
 
-    <div id="side-grouped">
-        {% for glyph_set, section in test_strings.items() %}
-        <h3>Glyphset: {{ glyph_set }}</h3>
-        {% for font_class in font_styles or font_styles_old or font_styles_new %}
+    
+
+<div id="font-by-font" style="display: none;">
+{% for glyph_set, section in test_strings.items() %}
+    <h3>Glyphset: {{ glyph_set }}</h3>
+    {% for font_class in font_styles or font_styles_old or font_styles_new %}
         <div class="box-title">{{ font_class.class_name }} {{ pt_size }}pt</div>
         {% for section_title, strings in section.items() %}
             <div class="box">
-            <div class="box-title">{{ section_title }}</div>
-            {% for string in strings %}
-                <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">
-                    {{ string }}<br>
+                <div class="box-title">{{ section_title }}</div>
+                {% for string in strings %}
+                    <div class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+    {% endfor %}
+{% endfor %} 
+</div>
+
+
+<div id="side-by-side" style="display: none;">
+{% for glyph_set, section in test_strings.items() %}
+    <h3>Glyphset: {{ glyph_set }}</h3>
+    {% for font_class in font_styles or font_styles_old or font_styles_new %}
+        <div class="box-side-by-side">
+            <div class="box-title">{{ font_class.class_name }} {{ pt_size }}pt</div>
+            {% for section_title, strings in section.items() %}
+                <div class="box">
+                    <div class="box-title">{{ section_title }}</div>
+                    {% for string in strings %}
+                        <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                    {% endfor %}
                 </div>
             {% endfor %}
-            <br>
-            {% endfor %}
         </div>
-        {% endfor %}
-    {% endfor %} 
-    </div>
+    {% endfor %}
+{% endfor %} 
+</div>
 
-    <script>
-        visible = true
-        function toggleGroup() {
-            var toggle = document.getElementById("toggle")
-            if (visible === true) {
-                document.getElementById("family-grouped").style.display = "none"
-                document.getElementById("side-grouped").style.display = "block"
-                visible = false
-                toggle.innerHTML = "Fonts stacked"
-            } else {
-                document.getElementById("family-grouped").style.display = "block"
-                document.getElementById("side-grouped").style.display = "none"
-                visible = true
-                toggle.innerHTML = "Line by line"
+
+{% endblock %}
+{% block js %}
+    
+state = "line-by-line"
+function viewMode() {
+    var viewButton = document.getElementById("view-button")
+    if (state === "line-by-line") {
+        document.getElementById("line-by-line").style.display = "none"
+        document.getElementById("font-by-font").style.display = "block"
+        document.getElementById("side-by-side").style.display = "none"
+        state = "font-by-font"
+        viewButton.innerHTML = "Font by font"
+    } else if (state === "font-by-font") {
+        document.getElementById("line-by-line").style.display = "none"
+        document.getElementById("font-by-font").style.display = "none"
+        document.getElementById("side-by-side").style.display = "block"
+        state = "side-by-side"
+        viewButton.innerHTML = "Side by side"
+    } else if (state === "side-by-side") {
+        document.getElementById("line-by-line").style.display = "block"
+        document.getElementById("font-by-font").style.display = "none"
+        document.getElementById("side-by-side").style.display = "none"
+        state = "line-by-line"
+        viewButton.innerHTML = "Line by line"
+    }
+}
+document.getElementById("view-button").addEventListener("click", viewMode)
+    
+    var ptSelector = document.getElementById("pt-selector");
+    ptSelector.addEventListener("change", function(e) {
+        var newPtSize = e.target.value
+        textBoxes = document.getElementsByClassName("texty")
+        for (i=0; i<textBoxes.length; i++) {
+            var textBox = textBoxes[i]
+            textBox.style.fontSize = newPtSize
+        }
+
+    })
+
+// break text for side by side view
+async function breakText() {
+var boxContent = document.getElementsByClassName("box-side-by-side")
+var paragraphs = boxContent[0].getElementsByClassName("texty")
+
+for (j=0; j<paragraphs.length; j++) {
+    res = []
+    for (i=0; i<boxContent.length; i++) {
+        box = boxContent[i]
+        paras = box.getElementsByClassName("texty")
+        para = paras[j]
+        breaks = getLineBreaks(para)
+        // populate if empty
+        if (res.length === 0) {
+            res = breaks
+        // replace tighter linebreaks
+        } else {
+            for (k=0; k<breaks.length; k++) {
+                if (k >= res.length) {
+                    res.push(breaks[k])
+                } else if (breaks[k] <= res[k]) {
+                    res[k] = breaks[k]
+                }
             }
         }
-        document.getElementById("toggle").addEventListener("click", toggleGroup)
-        
-        var ptSelector = document.getElementById("pt-selector");
-        ptSelector.addEventListener("change", function(e) {
-            var newPtSize = e.target.value
-            textBoxes = document.getElementsByClassName("texty")
-            for (i=0; i<textBoxes.length; i++) {
-                var textBox = textBoxes[i]
-                textBox.style.fontSize = newPtSize
-            }
 
-        })
-    </script>
+    }
+    for (ii=0; ii<boxContent.length; ii++) {
+        box = boxContent[ii]
+        paras = box.getElementsByClassName("texty")
+        para = paras[j]
+        insertBreaks(para, res)
+    }
+}
+}
+
+
+function getLineBreaks(elem) {
+const nodes = grabTextNodes(elem);
+for (const node of nodes) { // each node is a big block of text
+    let rangeIndex = 1;
+    let textIndex = 0;
+    let nodeText = node.textContent;
+    const textLength = nodeText.length;
+
+    linebreaks = []
+    prevTop = 0;
+    while (rangeIndex <= textLength) {
+        const range = document.createRange();
+        range.setStart(node, rangeIndex-1);
+        range.setEnd(node, rangeIndex)
+        currentTop = range.getBoundingClientRect().top
+    if (currentTop > prevTop) {
+        if (rangeIndex-2 !== -1) {
+            linebreaks.push(rangeIndex-2)
+        }
+    }
+    rangeIndex += 1;
+    prevTop = currentTop
+    }
+}
+return linebreaks
+}
+
+function grabTextNodes(elem) {
+const walker = document.createTreeWalker(elem, NodeFilter.SHOW_TEXT, null);
+const nodes = [];
+while (walker.nextNode()) {
+    nodes.push(walker.currentNode);
+}
+return nodes;
+}
+
+function insertBreaks(node, breaks) {
+console.log(node.innerHTML, breaks)
+newText = ""
+currentText = node.textContent
+for (jj=0; jj<currentText.length; jj++) {
+    if (breaks.includes(jj)) {
+        newText += "<br>"
+    } else {
+        newText += currentText[jj]
+    }
+}
+node.innerHTML = newText
+}
+
+
 {% endblock %}

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -13,14 +13,13 @@
     font-size: 9pt;
 }
 #view-button {
-    padding: 5px;
-    color: white;
-    background-color: black;
-
 }
 #pt-dropdown {
     padding: 5px;
-    background-color: white;
+}
+#pt-selector {
+    background-color: black;
+    color: white;
 }
 #side-by-side {
     width: 6000px;
@@ -36,12 +35,10 @@
 {% block content_name %}
 <b>Proofer</b>
 {% endblock %}
-{% block content %}
-<div id="toolbar">
-    <div id="view-button">
-        Line by line
-    </div>
-    <div id="pt-dropdown">
+
+{% block nav %}
+    <div class="nav-item" id="view-button">Line by line</div>
+    <div class="nav-item" id="pt-dropdown">
         <label for="pt-size">Font Size:</label>
             <select id="pt-selector" name="pt">
             <option value="10pt">10pt</option>
@@ -50,8 +47,9 @@
             <option value="96pt">96pt</option>
         </select>
     </div>
-</div>
+{% endblock %}
 
+{% block content %}
 <div id="line-by-line" style="display: block;">
         {% for glyph_set, section in test_strings.items() %}
         <h3>Glyphset: {{ glyph_set }}</h3>

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -1,0 +1,24 @@
+{% extends "_base.html" %}
+{% block title %}Proofer{% endblock %}
+
+{% block content_name %}
+<b>Proofer</b>
+{% endblock %}
+{% block content %}
+    {% for glyph_set, section in test_strings.items() %}
+        <h3>Glyphset: {{ glyph_set }}</h3>
+        {% for section_title, strings in section.items() %}
+            <div class="box">
+            <div class="box-title">{{ section_title }}</div>
+            {% for string in strings %}
+            {% for font_class in font_styles or font_styles_old or font_styles_new %}
+                <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+                    {{ string }}<br>
+                </span>
+            {% endfor %}
+            <br>
+            {% endfor %}
+        </div>
+        {% endfor %}
+    {% endfor %}
+{% endblock %}

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -58,7 +58,7 @@
             <div class="box-title">{{ section_title }}</div>
             {% for string in strings %}
             {% for font_class in font_styles or font_styles_old or font_styles_new %}
-                <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">
+                <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
                     {{ string }}<br>
                 </div>
             {% endfor %}
@@ -80,7 +80,7 @@
             <div class="box">
                 <div class="box-title">{{ section_title }}</div>
                 {% for string in strings %}
-                    <div class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                    <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">{{ string }}</div>
                 {% endfor %}
             </div>
         {% endfor %}
@@ -99,7 +99,7 @@
                 <div class="box">
                     <div class="box-title">{{ section_title }}</div>
                     {% for string in strings %}
-                        <div class="{{ font_class.class_name }} texty" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                        <div class="box-text {{ font_class.class_name }} box-text" style="font-size: {{ pt_size }}pt">{{ string }}</div>
                     {% endfor %}
                 </div>
             {% endfor %}
@@ -141,7 +141,7 @@ document.getElementById("view-button").addEventListener("click", viewMode)
     var ptSelector = document.getElementById("pt-selector");
     ptSelector.addEventListener("change", function(e) {
         var newPtSize = e.target.value
-        textBoxes = document.getElementsByClassName("texty")
+        textBoxes = document.getElementsByClassName("box-text")
         for (i=0; i<textBoxes.length; i++) {
             var textBox = textBoxes[i]
             textBox.style.fontSize = newPtSize
@@ -152,13 +152,13 @@ document.getElementById("view-button").addEventListener("click", viewMode)
 // break text for side by side view
 async function breakText() {
 var boxContent = document.getElementsByClassName("box-side-by-side")
-var paragraphs = boxContent[0].getElementsByClassName("texty")
+var paragraphs = boxContent[0].getElementsByClassName("box-text")
 
 for (j=0; j<paragraphs.length; j++) {
     res = []
     for (i=0; i<boxContent.length; i++) {
         box = boxContent[i]
-        paras = box.getElementsByClassName("texty")
+        paras = box.getElementsByClassName("box-text")
         para = paras[j]
         breaks = getLineBreaks(para)
         // populate if empty
@@ -178,7 +178,7 @@ for (j=0; j<paragraphs.length; j++) {
     }
     for (ii=0; ii<boxContent.length; ii++) {
         box = boxContent[ii]
-        paras = box.getElementsByClassName("texty")
+        paras = box.getElementsByClassName("box-text")
         para = paras[j]
         insertBreaks(para, res)
     }
@@ -237,7 +237,7 @@ node.innerHTML = newText
 }
 
 function longestLine() {
-    var paragraphs = document.getElementsByClassName("texty")
+    var paragraphs = document.getElementsByClassName("box-text")
     var res = 0
     for (i=0; i<paragraphs.length; i++) {
         var cur = lineLength(paragraphs[i])

--- a/src/diffenator2/templates/diffenator.html
+++ b/src/diffenator2/templates/diffenator.html
@@ -44,13 +44,13 @@
     {% if diff.glyph_diff["glyphs"].new %}
       <div class="box">
         <div class="box-title">New encoded glyphs</div>
-        <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+        <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
           {% for glyph in diff.glyph_diff["glyphs"].new %}
             <div class="cell">
               {{ glyph.render() }}
             </div>
           {% endfor %}
-        </span>
+          </div>
       </div>
     {% endif %}
     
@@ -58,47 +58,47 @@
     {% if diff.glyph_diff["glyphs"].missing %}
       <div class="box">
         <div class="box-title">Missing encoded Glyphs</div>
-        <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+        <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
           {% for glyph in diff.glyph_diff["glyphs"].missing %}
             <div class="cell">
               {{ glyph.render() }}
             </div>
           {% endfor %}
-        </span>
+          </div>
       </div>
     {% endif %}
     
     {% if diff.glyph_diff["glyphs"].modified %}
       <div class="box">
         <div class="box-title">Modified encoded Glyphs</div>
-        <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+        <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
           {% for glyph in diff.glyph_diff["glyphs"].modified %}
             <div class="cell">
               {{ glyph.render() }}
             </div>
           {% endfor %}
-        </span>
+          </div>
       </div>
     {% endif %}
 
     {% for script in diff.glyph_diff["words"] %}
       <div class="box">
         <div class="box-title">Misshapen {{ script }} words</div>
-        <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+        <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
           {% for word in diff.glyph_diff["words"][script] %}
               {{ word.render() }}
           {% endfor %}
-        </span>
+        </div>
       </div>
     {% endfor %}
     
     <div class="box">
       <div class="box-title">Misshapen user strings</div>
-      <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
+      <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
         {% for word in diff.strings %}
             {{ word.render() }}
         {% endfor %}
-      </span>
+      </div>
     </div>
     
 

--- a/src/diffenator2/utils.py
+++ b/src/diffenator2/utils.py
@@ -119,7 +119,7 @@ def gen_gifs(dir1: str, dir2: str, dst_dir: str):
     for img in shared_imgs:
         # We use apng format since a gif's dimensions are limited to 64kx64k
         # we have encountered many diffs which are taller than this.
-        gif_filename = img[:-4] + ".apng"
+        gif_filename = img[:-4] + ".gif"
         img_a_path = os.path.join(dir1, img)
         img_b_path = os.path.join(dir2, img)
         dst = os.path.join(dst_dir, gif_filename)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -44,8 +44,8 @@ def test_run_diffbrowsers_proof_imgs(fp):
                     html.append(f)
                 else:
                     imgs.append(f)
-        # There should at least be an image for each html page
-        assert len(imgs) >= len(html)
+        # There should at least be an image for each html page apart from the proofing page
+        assert len(imgs) >= len(html)-1
 
 
 


### PR DESCRIPTION
This PR adds a proofing page to diffbrowsers. 

<img width="1552" alt="Screenshot 2023-03-21 at 14 00 24" src="https://user-images.githubusercontent.com/7525512/226629566-8546d14a-a975-4222-9d2c-28349d8f6b97.png">

Primary motivation for this page is to help us proof new families.

Decided to also fix #29 and #36 as well.