### PR TITLE
Use adobe notdef

### DIFF
--- a/src/diffenator2/templates/CSSFontStyle.partial.html
+++ b/src/diffenator2/templates/CSSFontStyle.partial.html
@@ -1,5 +1,5 @@
 .{{class_name}}{
-    font-family: "{{ cssfamilyname }}";
+    font-family: "{{ cssfamilyname }}", "Adobe NotDef";
     {% if "wght" in coords %}font-weight: {{coords['wght']}};{% endif %}
     {% if "wdth" in coords %}font-stretch: {{coords['wdth']}}%;{% endif %}
     {% if "Italic" in stylename %}font-style: italic;{% else %}font-style: normal;{% endif %}

--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -10,6 +10,10 @@
         html{
 	  font-family: sans-serif;
 	}
+    @font-face {
+        font-family: "Adobe NotDef";
+        src: url(https://cdn.jsdelivr.net/gh/adobe-fonts/adobe-notdef/AND-Regular.ttf);
+    }
 	.box-title{
 	  width: 100%;
 	  float: left;


### PR DESCRIPTION
Fixes #40, and makes missing glyphs more obvious:

<img width="491" alt="Screenshot 2023-03-23 at 11 30 15" src="https://user-images.githubusercontent.com/106728/227190631-39d95dd0-d523-4715-b56d-02e49a644bfd.png">
