### PR TITLE
Share assets directory

### DIFF
--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -25,12 +25,16 @@ def ninja_proof(
     styles="instances",
     filter_styles: str = None,
     pt_size: int = 20,
+    assets_dir: str = "out",
 ):
     if not os.path.exists(out):
         os.mkdir(out)
 
+    if not os.path.exists(assets_dir):
+        os.mkdir(assets_dir)
+
     if filter_styles:
-        _ninja_proof(fonts, out, imgs, styles, filter_styles, pt_size)
+        _ninja_proof(fonts, out, imgs, styles, filter_styles, pt_size, assets_dir)
         return
 
     font_styles = get_font_styles(fonts, styles)
@@ -40,7 +44,7 @@ def ninja_proof(
         o = os.path.join(out, filter_styles.replace("|", "-"))
         if not os.path.exists(o):
             os.mkdir(o)
-        _ninja_proof(fonts, o, imgs, styles, filter_styles, pt_size)
+        _ninja_proof(fonts, o, imgs, styles, filter_styles, pt_size, assets_dir)
 
 
 def _ninja_proof(
@@ -50,13 +54,14 @@ def _ninja_proof(
     styles: str = "instances",
     filter_styles: bool = None,
     pt_size: int = 20,
+    assets_dir: str = "out",
 ):
     w = Writer(open(NINJA_BUILD_FILE, "w", encoding="utf8"))
     w.comment("Rules")
     w.newline()
     out_s = os.path.join("out", "diffbrowsers")
 
-    cmd = f"_diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size"
+    cmd = f"_diffbrowsers proof --assets-dir $assets_dir $fonts -s $styles -o $out -pt $pt_size"
     if imgs:
         cmd += " --imgs"
     if filter_styles:
@@ -70,7 +75,8 @@ def _ninja_proof(
         fonts=[os.path.abspath(f.ttFont.reader.file.name) for f in fonts],
         styles=styles,
         out=out_s,
-        pt_size=pt_size
+        pt_size=pt_size,
+        assets_dir=assets_dir,
     )
     if imgs:
         variables["imgs"] = imgs
@@ -93,6 +99,7 @@ def ninja_diff(
     filter_styles: str = None,
     pt_size: int = 20,
     threshold: float = THRESHOLD,
+    assets_dir: str = "out",
 ):
     if not os.path.exists(out):
         os.mkdir(out)
@@ -110,6 +117,7 @@ def ninja_diff(
             filter_styles,
             pt_size,
             threshold=threshold,
+            assets_dir=assets_dir,
         )
         return
 

--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -141,6 +141,7 @@ def ninja_diff(
             filter_styles,
             pt_size,
             threshold=threshold,
+            assets_dir=out,
         )
 
 def _ninja_diff(
@@ -155,13 +156,14 @@ def _ninja_diff(
     filter_styles: str = None,
     pt_size: int = 20,
     threshold: float = THRESHOLD,
+    assets_dir: str = "out",
 ):
     w = Writer(open(NINJA_BUILD_FILE, "w", encoding="utf8"))
     # Setup rules
     w.comment("Rules")
     w.newline()
     w.comment("Build Hinting docs")
-    db_cmd = f"_diffbrowsers diff -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size"
+    db_cmd = f"_diffbrowsers diff --assets-dir $assets_dir -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size"
     if imgs:
         db_cmd += " --imgs"
     if filter_styles:
@@ -170,7 +172,7 @@ def _ninja_diff(
     w.newline()
 
     w.comment("Run diffenator VF")
-    diff_cmd = f"_diffenator $font_before $font_after -t $threshold -o $out"
+    diff_cmd = f"_diffenator --assets-dir $assets_dir $font_before $font_after -t $threshold -o $out"
     if user_wordlist:
         diff_cmd += " --user-wordlist $user_wordlist"
     diff_inst_cmd = diff_cmd + " --coords $coords"
@@ -187,6 +189,7 @@ def _ninja_diff(
             fonts_after=[os.path.abspath(f.ttFont.reader.file.name) for f in fonts_after],
             styles=styles,
             out=diffbrowsers_out,
+            assets_dir=assets_dir,
             pt_size=pt_size
         )
         if filter_styles:
@@ -202,6 +205,7 @@ def _ninja_diff(
                 font_before=old_style.font.ttFont.reader.file.name,
                 font_after=new_style.font.ttFont.reader.file.name,
                 out=style,
+                assets_dir=assets_dir,
                 threshold=threshold,
             )
             if user_wordlist:

--- a/src/diffenator2/_diffbrowsers.py
+++ b/src/diffenator2/_diffbrowsers.py
@@ -52,6 +52,10 @@ def main():
         "--out", "-o", help="Output dir", default="out"
     )
     universal_options_parser.add_argument(
+        "--assets-dir", help="Where to place font assets", default=None
+    )
+
+    universal_options_parser.add_argument(
         "--templates",
         help="HTML templates. By default, diffenator/templates/diffbrowsers_*.html is used.",
         default=glob(
@@ -87,6 +91,9 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.assets_dir:
+        args.assets_dir = args.out
+
     if args.command == "proof":
         fonts = [DFont(os.path.abspath(fp)) for fp in args.fonts]
         styles = get_font_styles(fonts, args.styles, args.filter_styles)
@@ -95,7 +102,8 @@ def main():
             args.templates,
             args.out,
             filter_styles=args.filter_styles,
-            pt_size=args.pt_size
+            pt_size=args.pt_size,
+            assets_dir=args.assets_dir,
         )
 
     elif args.command == "diff":
@@ -109,6 +117,7 @@ def main():
             args.out,
             filter_styles=args.filter_styles,
             pt_size=args.pt_size,
+            assets_dir=args.assets_dir,
         )
 
     if args.imgs:

--- a/src/diffenator2/_diffenator.py
+++ b/src/diffenator2/_diffenator.py
@@ -39,8 +39,8 @@ class DiffFonts:
     def diff_words(self):
         self.glyph_diff = test_fonts(self.old_font, self.new_font, threshold=self.threshold)
 
-    def to_html(self, templates, out):
-        diffenator_report(self, templates, dst=out)
+    def to_html(self, templates, out, assets_dir):
+        diffenator_report(self, templates, dst=out, assets_dir=assets_dir)
 
 
 def main():
@@ -59,7 +59,11 @@ def main():
     parser.add_argument("--coords", "-c", default={})
     parser.add_argument("--threshold", "-t", default=THRESHOLD, type=float)
     parser.add_argument("--out", "-o", default="out", help="Output html path")
+    parser.add_argument("--assets-dir", help="Where to put font assets")
     args = parser.parse_args()
+
+    if not args.assets_dir:
+        args.assets_dir = args.out
 
     coords = string_coords_to_dict(args.coords) if args.coords else None
 
@@ -73,7 +77,7 @@ def main():
     diff.diff_all()
     if args.user_wordlist:
         diff.diff_strings(args.user_wordlist)
-    diff.to_html(args.template, args.out)
+    diff.to_html(args.template, args.out, assets_dir=args.assets_dir)
 
 
 if __name__ == "__main__":

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -9,6 +9,7 @@ from diffenator2.template_elements import CSSFontStyle, CSSFontFace
 from diffenator2.utils import font_sample_text
 from glyphsets import GFTestData
 import re
+from pathlib import Path
 
 
 WIDTH_CLASS_TO_CSS = {
@@ -135,6 +136,18 @@ def _package(templates, dst, **kwargs):
     if not os.path.exists(dst):
         os.makedirs(dst)
 
+    if not os.path.exists(kwargs["assets_dir"]):
+        os.makedirs(kwargs["assets_dir"])
+
+    # copy fonts
+    # make this more general purpose for ttfont objects
+    for k in ("font_faces", "font_faces_old", "font_faces_new"):
+        if k in kwargs:
+            for font in kwargs[k]:
+                out_fp = os.path.join(kwargs["assets_dir"], font.filename)
+                shutil.copy(font.ttfont.reader.file.name, out_fp)
+                font.filename = os.path.relpath(Path(out_fp).resolve(), Path(dst).resolve())
+
     # write docs
     for template_fp in templates:
         env = Environment(
@@ -145,11 +158,3 @@ def _package(templates, dst, **kwargs):
         dst_doc = os.path.join(dst, os.path.basename(template_fp))
         with open(dst_doc, "w", encoding="utf8") as out_file:
             out_file.write(doc)
-
-    # copy fonts
-    # make this more general purpose for ttfont objects
-    for k in ("font_faces", "font_faces_old", "font_faces_new"):
-        if k in kwargs:
-            for font in kwargs[k]:
-                out_fp = os.path.join(dst, font.filename)
-                shutil.copy(font.ttfont.reader.file.name, out_fp)

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -60,22 +60,6 @@ def static_font_style(ttfont, suffix=""):
     )
 
 
-def diffenator_font_style(dfont, suffix=""):
-    ttfont = dfont.ttFont
-    if dfont.is_variable() and hasattr(dfont, "variations"):
-        style_name = ttfont["name"].getBestSubFamilyName()
-        coords = dfont.variations
-    else:
-        style_name = ttfont["name"].getBestSubFamilyName()
-        coords = {"wght": ttfont["OS/2"].usWeightClass}
-    return CSSFontStyle(
-        "font",
-        "style",
-        coords,
-        suffix,
-    )
-
-
 def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20):
     ttFont = styles[0].font.ttFont
     font_faces = set(style.font.css_font_face for style in styles)

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -60,7 +60,7 @@ def static_font_style(ttfont, suffix=""):
     )
 
 
-def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20):
+def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20, assets_dir="out"):
     ttFont = styles[0].font.ttFont
     font_faces = set(style.font.css_font_face for style in styles)
     font_styles = [style.css_font_style for style in styles]
@@ -76,10 +76,11 @@ def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20
         glyphs=glyphs,
         test_strings=test_strings,
         pt_size=pt_size,
+        assets_dir=assets_dir,
     )
 
 
-def diff_rendering(matcher, templates, dst="out", filter_styles=None, pt_size=20):
+def diff_rendering(matcher, templates, dst="out", filter_styles=None, pt_size=20, assets_dir="out"):
     ttFont = matcher.old_styles[0].font.ttFont
     font_faces_old = set(style.font.css_font_face for style in matcher.old_styles)
     font_styles_old = [style.css_font_style for style in matcher.old_styles]
@@ -102,10 +103,11 @@ def diff_rendering(matcher, templates, dst="out", filter_styles=None, pt_size=20
         glyphs=glyphs,
         test_strings=test_strings,
         pt_size=pt_size,
+        assets_dir=assets_dir,
     )
 
 
-def diffenator_report(diff, template, dst="out"):
+def diffenator_report(diff, template, dst="out", assets_dir="out"):
     font_faces_old = [diff.old_font.css_font_face]
     font_faces_old[0].cssfamilyname = "old font"
     font_faces_new = [diff.new_font.css_font_face]
@@ -125,6 +127,7 @@ def diffenator_report(diff, template, dst="out"):
         font_styles_new=font_styles_new,
         include_ui=True,
         pt_size=32,
+        assets_dir=assets_dir,
     )
 
 

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -60,12 +60,6 @@ def static_font_style(ttfont, suffix=""):
     )
 
 
-def diffenator_font_face(dfont, suffix=""):
-    face = CSSFontFace(dfont, suffix)
-    face.cssfamilyname = f"{suffix} font"
-    return face
-
-
 def diffenator_font_style(dfont, suffix=""):
     ttfont = dfont.ttFont
     if dfont.is_variable() and hasattr(dfont, "variations"):

--- a/src/diffenator2/renderer.py
+++ b/src/diffenator2/renderer.py
@@ -215,6 +215,8 @@ class PixelDiffer:
         img_b = self.renderer_b.render(string)
         width = min([img_a.width, img_b.width])
         height = min([img_a.height, img_b.height])
+        if not np.asarray(img_a).shape:  # empty array
+            return 0, []
         img_a = np.asarray(img_a)[0:height, 0:width, :]
         img_b = np.asarray(img_b)[0:height, 0:width, :]
 

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -2,43 +2,43 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
-      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size --imgs \$
-      --filter-styles "\$filters"
+  command = _diffbrowsers diff --assets-dir $assets_dir -fb $fonts_before $
+      -fa $fonts_after -s $styles -o $out -pt $pt_size --imgs $
+      --filter-styles "$filters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out
 rule diffenator-inst
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out --coords \$coords
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out --coords $coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
-  fonts_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  fonts_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  fonts_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  fonts_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
   assets_dir = out
   pt_size = 20
   filters = Medium|ExtraBold
 build out/ExtraBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = ExtraBold
   assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Medium
   assets_dir = out
   threshold = 0.9

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -2,15 +2,17 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size --imgs --filter-styles "\$filters"
+  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
+      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size --imgs \$
+      --filter-styles "\$filters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -20,6 +22,7 @@ build out/diffbrowsers: diffbrowsers
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
+  assets_dir = out
   pt_size = 20
   filters = Medium|ExtraBold
 build out/ExtraBold: diffenator-inst
@@ -28,6 +31,7 @@ build out/ExtraBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = ExtraBold
+  assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
@@ -36,5 +40,6 @@ build out/Medium: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Medium
+  assets_dir = out
   threshold = 0.9
   coords = wght=500.0

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -2,77 +2,77 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
-      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size --imgs
+  command = _diffbrowsers diff --assets-dir $assets_dir -fb $fonts_before $
+      -fa $fonts_after -s $styles -o $out -pt $pt_size --imgs
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out
 rule diffenator-inst
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out --coords \$coords
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out --coords $coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
-  fonts_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  fonts_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  fonts_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  fonts_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
   assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Black
   assets_dir = out
   threshold = 0.9
   coords = wght=900.0
 build out/Bold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Bold
   assets_dir = out
   threshold = 0.9
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = ExtraBold
   assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Medium
   assets_dir = out
   threshold = 0.9
   coords = wght=500.0
 build out/Regular: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Regular
   assets_dir = out
   threshold = 0.9
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = SemiBold
   assets_dir = out
   threshold = 0.9

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -2,15 +2,16 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size --imgs
+  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
+      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size --imgs
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -20,6 +21,7 @@ build out/diffbrowsers: diffbrowsers
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
+  assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
   font_before = \$
@@ -27,6 +29,7 @@ build out/Black: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Black
+  assets_dir = out
   threshold = 0.9
   coords = wght=900.0
 build out/Bold: diffenator-inst
@@ -35,6 +38,7 @@ build out/Bold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Bold
+  assets_dir = out
   threshold = 0.9
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
@@ -43,6 +47,7 @@ build out/ExtraBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = ExtraBold
+  assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
@@ -51,6 +56,7 @@ build out/Medium: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Medium
+  assets_dir = out
   threshold = 0.9
   coords = wght=500.0
 build out/Regular: diffenator-inst
@@ -59,6 +65,7 @@ build out/Regular: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Regular
+  assets_dir = out
   threshold = 0.9
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
@@ -67,5 +74,6 @@ build out/SemiBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = SemiBold
+  assets_dir = out
   threshold = 0.9
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -2,77 +2,77 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
-      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers diff --assets-dir $assets_dir -fb $fonts_before $
+      -fa $fonts_after -s $styles -o $out -pt $pt_size
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out
 rule diffenator-inst
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out --coords \$coords
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out --coords $coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
-  fonts_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  fonts_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  fonts_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  fonts_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
   assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Black
   assets_dir = out
   threshold = 0.9
   coords = wght=900.0
 build out/Bold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Bold
   assets_dir = out
   threshold = 0.9
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = ExtraBold
   assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Medium
   assets_dir = out
   threshold = 0.9
   coords = wght=500.0
 build out/Regular: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Regular
   assets_dir = out
   threshold = 0.9
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = SemiBold
   assets_dir = out
   threshold = 0.9

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -2,15 +2,16 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
+      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -20,6 +21,7 @@ build out/diffbrowsers: diffbrowsers
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
+  assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
   font_before = \$
@@ -27,6 +29,7 @@ build out/Black: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Black
+  assets_dir = out
   threshold = 0.9
   coords = wght=900.0
 build out/Bold: diffenator-inst
@@ -35,6 +38,7 @@ build out/Bold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Bold
+  assets_dir = out
   threshold = 0.9
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
@@ -43,6 +47,7 @@ build out/ExtraBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = ExtraBold
+  assets_dir = out
   threshold = 0.9
   coords = wght=800.0
 build out/Medium: diffenator-inst
@@ -51,6 +56,7 @@ build out/Medium: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Medium
+  assets_dir = out
   threshold = 0.9
   coords = wght=500.0
 build out/Regular: diffenator-inst
@@ -59,6 +65,7 @@ build out/Regular: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Regular
+  assets_dir = out
   threshold = 0.9
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
@@ -67,5 +74,6 @@ build out/SemiBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = SemiBold
+  assets_dir = out
   threshold = 0.9
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-threshold.txt
+++ b/tests/data/ninja_files/diff-threshold.txt
@@ -2,77 +2,77 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
-      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers diff --assets-dir $assets_dir -fb $fonts_before $
+      -fa $fonts_after -s $styles -o $out -pt $pt_size
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out
 rule diffenator-inst
-  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
-      -t \$threshold -o \$out --coords \$coords
+  command = _diffenator --assets-dir $assets_dir $font_before $font_after $
+      -t $threshold -o $out --coords $coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
-  fonts_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  fonts_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  fonts_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  fonts_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
   assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Black
   assets_dir = out
   threshold = 0.01
   coords = wght=900.0
 build out/Bold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Bold
   assets_dir = out
   threshold = 0.01
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = ExtraBold
   assets_dir = out
   threshold = 0.01
   coords = wght=800.0
 build out/Medium: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Medium
   assets_dir = out
   threshold = 0.01
   coords = wght=500.0
 build out/Regular: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = Regular
   assets_dir = out
   threshold = 0.01
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
-  font_before = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
-  font_after = \$
-      .*/tests/data/MavenPro\[wght\].subset.mod.ttf
+  font_before = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
+  font_after = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.mod.ttf
   out = SemiBold
   assets_dir = out
   threshold = 0.01

--- a/tests/data/ninja_files/diff-threshold.txt
+++ b/tests/data/ninja_files/diff-threshold.txt
@@ -2,15 +2,16 @@
 
 # Build Hinting docs
 rule diffbrowsers
-  command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers diff --assets-dir \$assets_dir -fb \$fonts_before \$
+      -fa \$fonts_after -s \$styles -o \$out -pt \$pt_size
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator --assets-dir \$assets_dir \$font_before \$font_after \$
+      -t \$threshold -o \$out --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -20,6 +21,7 @@ build out/diffbrowsers: diffbrowsers
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   styles = instances
   out = out/diffbrowsers
+  assets_dir = out
   pt_size = 20
 build out/Black: diffenator-inst
   font_before = \$
@@ -27,6 +29,7 @@ build out/Black: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Black
+  assets_dir = out
   threshold = 0.01
   coords = wght=900.0
 build out/Bold: diffenator-inst
@@ -35,6 +38,7 @@ build out/Bold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Bold
+  assets_dir = out
   threshold = 0.01
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
@@ -43,6 +47,7 @@ build out/ExtraBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = ExtraBold
+  assets_dir = out
   threshold = 0.01
   coords = wght=800.0
 build out/Medium: diffenator-inst
@@ -51,6 +56,7 @@ build out/Medium: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Medium
+  assets_dir = out
   threshold = 0.01
   coords = wght=500.0
 build out/Regular: diffenator-inst
@@ -59,6 +65,7 @@ build out/Regular: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = Regular
+  assets_dir = out
   threshold = 0.01
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
@@ -67,5 +74,6 @@ build out/SemiBold: diffenator-inst
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = SemiBold
+  assets_dir = out
   threshold = 0.01
   coords = wght=600.0

--- a/tests/data/ninja_files/proof-filter-styles.txt
+++ b/tests/data/ninja_files/proof-filter-styles.txt
@@ -1,13 +1,13 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size --imgs \$
-      --filter-styles "\$filters"
+  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size $
+      --imgs --filter-styles "$filters"
 
 # Build rules
 build out: proofing
   fonts = $
-      .*/tests/data/MavenPro\[wght\].subset.ttf
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
   styles = instances
   out = out/diffbrowsers
   pt_size = 20

--- a/tests/data/ninja_files/proof-filter-styles.txt
+++ b/tests/data/ninja_files/proof-filter-styles.txt
@@ -1,8 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size $
-      --imgs --filter-styles "$filters"
+  command = _diffbrowsers proof --assets-dir $assets_dir $fonts -s $styles $
+      -o $out -pt $pt_size --imgs --filter-styles "$filters"
 
 # Build rules
 build out: proofing
@@ -11,5 +11,6 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  assets_dir = out
   imgs = True
   filters = Medium|Bold

--- a/tests/data/ninja_files/proof-imgs.txt
+++ b/tests/data/ninja_files/proof-imgs.txt
@@ -1,7 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size --imgs
+  command = _diffbrowsers proof --assets-dir $assets_dir $fonts -s $styles $
+      -o $out -pt $pt_size --imgs
 
 # Build rules
 build out: proofing
@@ -10,4 +11,5 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  assets_dir = out
   imgs = True

--- a/tests/data/ninja_files/proof-imgs.txt
+++ b/tests/data/ninja_files/proof-imgs.txt
@@ -1,12 +1,12 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size --imgs
+  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size --imgs
 
 # Build rules
 build out: proofing
-  fonts = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
+  fonts = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
   styles = instances
   out = out/diffbrowsers
   pt_size = 20

--- a/tests/data/ninja_files/proof-standard.txt
+++ b/tests/data/ninja_files/proof-standard.txt
@@ -1,12 +1,12 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size
 
 # Build rules
 build out: proofing
-  fonts = \$
-      .*/tests/data/MavenPro\[wght\].subset.ttf
+  fonts = $
+      [SOMEDIRECTORY]/tests/data/MavenPro[wght].subset.ttf
   styles = instances
   out = out/diffbrowsers
   pt_size = 20

--- a/tests/data/ninja_files/proof-standard.txt
+++ b/tests/data/ninja_files/proof-standard.txt
@@ -1,7 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size
+  command = _diffbrowsers proof --assets-dir $assets_dir $fonts -s $styles $
+      -o $out -pt $pt_size
 
 # Build rules
 build out: proofing
@@ -10,3 +11,4 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  assets_dir = out

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -2,7 +2,6 @@ import pytest
 from . import *
 from itertools import combinations
 from diffenator2.font import DFont
-from diffenator2.html import diffenator_font_style
 from diffenator2.matcher import FontMatcher
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,6 +2,21 @@ import pytest
 from tests import *
 from diffenator2.html import CSSFontStyle
 
+def diffenator_font_style(dfont, suffix=""):
+    ttfont = dfont.ttFont
+    if dfont.is_variable() and hasattr(dfont, "variations"):
+        style_name = ttfont["name"].getBestSubFamilyName()
+        coords = dfont.variations
+    else:
+        style_name = ttfont["name"].getBestSubFamilyName()
+        coords = {"wght": ttfont["OS/2"].usWeightClass}
+    return CSSFontStyle(
+        "font",
+        "style",
+        coords,
+        suffix,
+    )
+
 
 @pytest.mark.parametrize(
     "fp, expected",
@@ -12,7 +27,6 @@ from diffenator2.html import CSSFontStyle
     ]
 )
 def test_diffenator_font_style_static(fp, expected):
-    from diffenator2.html import diffenator_font_style
     from diffenator2.font import DFont
 
     font = DFont(fp)
@@ -28,7 +42,6 @@ def test_diffenator_font_style_static(fp, expected):
     ]
 )
 def test_diffenator_font_style_vf(fp, coords, expected):
-    from diffenator2.html import diffenator_font_style
     from diffenator2.font import DFont
 
     font = DFont(fp)

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -54,7 +54,8 @@ def test_run_ninja_diff(kwargs, expected_fp):
     with open(expected_fp) as expected, open("build.ninja") as current:
         exp = expected.read()
         cur = current.read()
-        assert re.search(exp, cur)
+        cur = re.sub(r"\S+/tests/data", "[SOMEDIRECTORY]/tests/data", cur)
+        assert exp == cur
 
 
 @pytest.mark.parametrize(
@@ -93,4 +94,5 @@ def test_run_ninja_proof(kwargs, expected_fp):
     with open(expected_fp) as expected, open("build.ninja") as current:
         exp = expected.read()
         cur = current.read()
-        assert re.search(exp, cur)
+        cur = re.sub(r"\S+/tests/data", "[SOMEDIRECTORY]/tests/data", cur)
+        assert exp == cur


### PR DESCRIPTION
This places all font assets in the same (output) directory, rather than copying each file to each report subdirectory.