### PR TITLE
Glyph filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ Compare variable fonts axes using a cross product
 
 Compare only ascii characters
 
-`diffenator2 diff -fb font2.ttf -fa font2.ttf -g "!-~"`
+`diffenator2 diff -fb font2.ttf -fa font2.ttf -ch "[!-~]"`

--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ Compare variable font masters
 Compare variable fonts axes using a cross product
 
 `diffenator2 diff -fb font1.ttf -fa font2.ttf -s cross_product`
+
+
+Compare only ascii characters
+
+`diffenator2 diff -fb font2.ttf -fa font2.ttf -g "!-~"`

--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -23,14 +23,14 @@ def ninja_proof(
     imgs: bool = False,
     styles="instances",
     filter_styles: str = "",
-    glyphs: str = ".*",
+    characters: str = ".*",
     pt_size: int = 20,
 ):
     if not os.path.exists(out):
         os.mkdir(out)
 
     if filter_styles:
-        _ninja_proof(fonts, out, imgs, styles, filter_styles, glyphs, pt_size)
+        _ninja_proof(fonts, out, imgs, styles, filter_styles, characters, pt_size)
         return
 
     font_styles = get_font_styles(fonts, styles)
@@ -40,7 +40,7 @@ def ninja_proof(
         o = os.path.join(out, filter_styles.replace("|", "-"))
         if not os.path.exists(o):
             os.mkdir(o)
-        _ninja_proof(fonts, o, imgs, styles, filter_styles, glyphs, pt_size)
+        _ninja_proof(fonts, o, imgs, styles, filter_styles, characters, pt_size)
 
 
 def _ninja_proof(
@@ -49,7 +49,7 @@ def _ninja_proof(
     imgs: bool = False,
     styles: str = "instances",
     filter_styles: str = "",
-    glyphs=".*",
+    characters=".*",
     pt_size: int = 20,
 ):
     w = Writer(open(NINJA_BUILD_FILE, "w", encoding="utf8"))
@@ -57,7 +57,7 @@ def _ninja_proof(
     w.newline()
     out_s = os.path.join("out", "diffbrowsers")
 
-    cmd = f'_diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size -g "$glyphs"'
+    cmd = f'_diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size -ch "$characters"'
     if imgs:
         cmd += " --imgs"
     if filter_styles:
@@ -72,7 +72,7 @@ def _ninja_proof(
         styles=styles,
         out=out_s,
         pt_size=pt_size,
-        glyphs=glyphs,
+        characters=characters,
     )
     if imgs:
         variables["imgs"] = imgs
@@ -91,7 +91,7 @@ def ninja_diff(
     out: str = "out",
     imgs: bool = False,
     styles: str = "instances",
-    glyphs: str = ".*",
+    characters: str = ".*",
     user_wordlist: str = "",
     filter_styles: str = "",
     pt_size: int = 20,
@@ -109,7 +109,7 @@ def ninja_diff(
             out,
             imgs,
             styles,
-            glyphs,
+            characters,
             user_wordlist,
             filter_styles,
             pt_size,
@@ -141,7 +141,7 @@ def ninja_diff(
             o,
             imgs,
             styles,
-            glyphs,
+            characters,
             user_wordlist,
             filter_styles,
             pt_size,
@@ -156,7 +156,7 @@ def _ninja_diff(
     out: str = "out",
     imgs: bool = False,
     styles="instances",
-    glyphs=".*",
+    characters=".*",
     user_wordlist: str = "",
     filter_styles: str = "",
     pt_size: int = 20,
@@ -167,7 +167,7 @@ def _ninja_diff(
     w.comment("Rules")
     w.newline()
     w.comment("Build Hinting docs")
-    db_cmd = f'_diffbrowsers diff -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size -g "$glyphs"'
+    db_cmd = f'_diffbrowsers diff -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size -ch "$characters"'
     if imgs:
         db_cmd += " --imgs"
     if filter_styles:
@@ -176,7 +176,7 @@ def _ninja_diff(
     w.newline()
 
     w.comment("Run diffenator VF")
-    diff_cmd = f'_diffenator $font_before $font_after -t $threshold -o $out -g "$glyphs"'
+    diff_cmd = f'_diffenator $font_before $font_after -t $threshold -o $out -ch "$characters"'
     if user_wordlist:
         diff_cmd += " --user-wordlist $user_wordlist"
     diff_inst_cmd = diff_cmd + " --coords $coords"
@@ -194,7 +194,7 @@ def _ninja_diff(
             styles=styles,
             out=diffbrowsers_out,
             pt_size=pt_size,
-            glyphs=glyphs,
+            characters=characters,
         )
         if filter_styles:
             db_variables["filters"] = filter_styles
@@ -210,7 +210,7 @@ def _ninja_diff(
                 font_after=f'"{new_style.font.ttFont.reader.file.name}"',
                 out=style,
                 threshold=str(threshold),
-                glyphs=glyphs,
+                characters=characters,
             )
             if user_wordlist:
                 diff_variables["user_wordlist"] = user_wordlist

--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -23,13 +23,14 @@ def ninja_proof(
     imgs: bool = False,
     styles="instances",
     filter_styles: str = "",
+    glyphs: str = ".*",
     pt_size: int = 20,
 ):
     if not os.path.exists(out):
         os.mkdir(out)
 
     if filter_styles:
-        _ninja_proof(fonts, out, imgs, styles, filter_styles, pt_size)
+        _ninja_proof(fonts, out, imgs, styles, filter_styles, glyphs, pt_size)
         return
 
     font_styles = get_font_styles(fonts, styles)
@@ -39,7 +40,7 @@ def ninja_proof(
         o = os.path.join(out, filter_styles.replace("|", "-"))
         if not os.path.exists(o):
             os.mkdir(o)
-        _ninja_proof(fonts, o, imgs, styles, filter_styles, pt_size)
+        _ninja_proof(fonts, o, imgs, styles, filter_styles, glyphs, pt_size)
 
 
 def _ninja_proof(
@@ -48,6 +49,7 @@ def _ninja_proof(
     imgs: bool = False,
     styles: str = "instances",
     filter_styles: str = "",
+    glyphs=".*",
     pt_size: int = 20,
 ):
     w = Writer(open(NINJA_BUILD_FILE, "w", encoding="utf8"))
@@ -55,7 +57,7 @@ def _ninja_proof(
     w.newline()
     out_s = os.path.join("out", "diffbrowsers")
 
-    cmd = f"_diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size"
+    cmd = f'_diffbrowsers proof $fonts -s $styles -o $out -pt $pt_size -g "$glyphs"'
     if imgs:
         cmd += " --imgs"
     if filter_styles:
@@ -69,7 +71,8 @@ def _ninja_proof(
         fonts=[f'"{os.path.abspath(f.ttFont.reader.file.name)}"' for f in fonts],
         styles=styles,
         out=out_s,
-        pt_size=pt_size
+        pt_size=pt_size,
+        glyphs=glyphs,
     )
     if imgs:
         variables["imgs"] = imgs
@@ -88,6 +91,7 @@ def ninja_diff(
     out: str = "out",
     imgs: bool = False,
     styles: str = "instances",
+    glyphs: str = ".*",
     user_wordlist: str = "",
     filter_styles: str = "",
     pt_size: int = 20,
@@ -105,6 +109,7 @@ def ninja_diff(
             out,
             imgs,
             styles,
+            glyphs,
             user_wordlist,
             filter_styles,
             pt_size,
@@ -136,6 +141,7 @@ def ninja_diff(
             o,
             imgs,
             styles,
+            glyphs,
             user_wordlist,
             filter_styles,
             pt_size,
@@ -150,6 +156,7 @@ def _ninja_diff(
     out: str = "out",
     imgs: bool = False,
     styles="instances",
+    glyphs=".*",
     user_wordlist: str = "",
     filter_styles: str = "",
     pt_size: int = 20,
@@ -160,7 +167,7 @@ def _ninja_diff(
     w.comment("Rules")
     w.newline()
     w.comment("Build Hinting docs")
-    db_cmd = f"_diffbrowsers diff -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size"
+    db_cmd = f'_diffbrowsers diff -fb $fonts_before -fa $fonts_after -s $styles -o $out -pt $pt_size -g "$glyphs"'
     if imgs:
         db_cmd += " --imgs"
     if filter_styles:
@@ -169,7 +176,7 @@ def _ninja_diff(
     w.newline()
 
     w.comment("Run diffenator VF")
-    diff_cmd = f"_diffenator $font_before $font_after -t $threshold -o $out"
+    diff_cmd = f'_diffenator $font_before $font_after -t $threshold -o $out -g "$glyphs"'
     if user_wordlist:
         diff_cmd += " --user-wordlist $user_wordlist"
     diff_inst_cmd = diff_cmd + " --coords $coords"
@@ -186,7 +193,8 @@ def _ninja_diff(
             fonts_after=[f'"{os.path.abspath(f.ttFont.reader.file.name)}"' for f in fonts_after],
             styles=styles,
             out=diffbrowsers_out,
-            pt_size=pt_size
+            pt_size=pt_size,
+            glyphs=glyphs,
         )
         if filter_styles:
             db_variables["filters"] = filter_styles
@@ -202,6 +210,7 @@ def _ninja_diff(
                 font_after=f'"{new_style.font.ttFont.reader.file.name}"',
                 out=style,
                 threshold=str(threshold),
+                glyphs=glyphs,
             )
             if user_wordlist:
                 diff_variables["user_wordlist"] = user_wordlist

--- a/src/diffenator2/__main__.py
+++ b/src/diffenator2/__main__.py
@@ -22,6 +22,7 @@ def main(**kwargs):
             "--imgs", help="Generate images", action="store_true", default=False
         )
         universal_options_parser.add_argument("--filter-styles", default=None)
+        universal_options_parser.add_argument("--glyphs", "-g", default=".*")
         universal_options_parser.add_argument("--pt-size", "-pt", default=20)
         universal_options_parser.add_argument(
             "--styles", "-s", choices=("instances", "cross_product", "masters"),
@@ -53,7 +54,13 @@ def main(**kwargs):
     if args.command == "proof":
         fonts = [DFont(f) for f in args.fonts]
         ninja_proof(
-            fonts, out=args.out, imgs=args.imgs, styles=args.styles, filter_styles=args.filter_styles, pt_size=args.pt_size
+            fonts,
+            out=args.out,
+            imgs=args.imgs,
+            styles=args.styles,
+            filter_styles=args.filter_styles,
+            glyphs=args.glyphs,
+            pt_size=args.pt_size,
         )
     elif args.command == "diff":
         fonts_before = [DFont(f) for f in args.fonts_before]
@@ -64,6 +71,7 @@ def main(**kwargs):
             out=args.out,
             imgs=args.imgs,
             styles=args.styles,
+            glyphs=args.glyphs,
             diffenator=False if args.no_diffenator else True,
             user_wordlist=args.user_wordlist,
             filter_styles=args.filter_styles,

--- a/src/diffenator2/__main__.py
+++ b/src/diffenator2/__main__.py
@@ -22,7 +22,7 @@ def main(**kwargs):
             "--imgs", help="Generate images", action="store_true", default=False
         )
         universal_options_parser.add_argument("--filter-styles", default=None)
-        universal_options_parser.add_argument("--glyphs", "-g", default=".*")
+        universal_options_parser.add_argument("--characters", "-ch", default=".*")
         universal_options_parser.add_argument("--pt-size", "-pt", default=20)
         universal_options_parser.add_argument(
             "--styles", "-s", choices=("instances", "cross_product", "masters"),
@@ -59,7 +59,7 @@ def main(**kwargs):
             imgs=args.imgs,
             styles=args.styles,
             filter_styles=args.filter_styles,
-            glyphs=args.glyphs,
+            characters=args.characters,
             pt_size=args.pt_size,
         )
     elif args.command == "diff":
@@ -71,7 +71,7 @@ def main(**kwargs):
             out=args.out,
             imgs=args.imgs,
             styles=args.styles,
-            glyphs=args.glyphs,
+            characters=args.characters,
             diffenator=False if args.no_diffenator else True,
             user_wordlist=args.user_wordlist,
             filter_styles=args.filter_styles,

--- a/src/diffenator2/_diffbrowsers.py
+++ b/src/diffenator2/_diffbrowsers.py
@@ -27,6 +27,7 @@ from pkg_resources import resource_filename
 from diffenator2.html import proof_rendering, diff_rendering
 from diffenator2.font import DFont, get_font_styles
 from diffenator2.matcher import FontMatcher
+from diffenator2.utils import re_filter_glyphs
 from glob import glob
 import os
 import argparse
@@ -64,6 +65,7 @@ def main():
         "--imgs", action="store_true", help="Generate images using headless browsers"
     )
     universal_options_parser.add_argument("--filter-styles", default=None)
+    universal_options_parser.add_argument("--glyphs", "-g", default=".*")
 
     proof_parser = subparsers.add_parser(
         "proof",
@@ -90,11 +92,14 @@ def main():
     if args.command == "proof":
         fonts = [DFont(os.path.abspath(fp)) for fp in args.fonts]
         styles = get_font_styles(fonts, args.styles, args.filter_styles)
+
+        glyphs = re_filter_glyphs(fonts[0], args.glyphs)
         proof_rendering(
             styles,
             args.templates,
             args.out,
             filter_styles=args.filter_styles,
+            glyphs=glyphs,
             pt_size=args.pt_size
         )
 
@@ -103,11 +108,13 @@ def main():
         fonts_after = [DFont(os.path.abspath(fp), suffix="new") for fp in args.fonts_after]
         matcher = FontMatcher(fonts_before, fonts_after)
         getattr(matcher, args.styles)(args.filter_styles)
+        glyphs = re_filter_glyphs(fonts_before[0], args.glyphs)
         diff_rendering(
             matcher,
             args.templates,
             args.out,
             filter_styles=args.filter_styles,
+            glyphs=glyphs,
             pt_size=args.pt_size,
         )
 

--- a/src/diffenator2/_diffbrowsers.py
+++ b/src/diffenator2/_diffbrowsers.py
@@ -27,7 +27,7 @@ from pkg_resources import resource_filename
 from diffenator2.html import proof_rendering, diff_rendering
 from diffenator2.font import DFont, get_font_styles
 from diffenator2.matcher import FontMatcher
-from diffenator2.utils import re_filter_glyphs
+from diffenator2.utils import re_filter_characters
 from glob import glob
 import os
 import argparse
@@ -65,7 +65,7 @@ def main():
         "--imgs", action="store_true", help="Generate images using headless browsers"
     )
     universal_options_parser.add_argument("--filter-styles", default=None)
-    universal_options_parser.add_argument("--glyphs", "-g", default=".*")
+    universal_options_parser.add_argument("--characters", "-ch", default=".*")
 
     proof_parser = subparsers.add_parser(
         "proof",
@@ -93,13 +93,13 @@ def main():
         fonts = [DFont(os.path.abspath(fp)) for fp in args.fonts]
         styles = get_font_styles(fonts, args.styles, args.filter_styles)
 
-        glyphs = re_filter_glyphs(fonts[0], args.glyphs)
+        characters = re_filter_characters(fonts[0], args.characters)
         proof_rendering(
             styles,
             args.templates,
             args.out,
             filter_styles=args.filter_styles,
-            glyphs=glyphs,
+            characters=characters,
             pt_size=args.pt_size
         )
 
@@ -108,13 +108,13 @@ def main():
         fonts_after = [DFont(os.path.abspath(fp), suffix="new") for fp in args.fonts_after]
         matcher = FontMatcher(fonts_before, fonts_after)
         getattr(matcher, args.styles)(args.filter_styles)
-        glyphs = re_filter_glyphs(fonts_before[0], args.glyphs)
+        characters = re_filter_characters(fonts_before[0], args.characters)
         diff_rendering(
             matcher,
             args.templates,
             args.out,
             filter_styles=args.filter_styles,
-            glyphs=glyphs,
+            characters=characters,
             pt_size=args.pt_size,
         )
 

--- a/src/diffenator2/_diffenator.py
+++ b/src/diffenator2/_diffenator.py
@@ -3,7 +3,7 @@
 diffenator2
 """
 from __future__ import annotations
-from diffenator2.utils import string_coords_to_dict, re_filter_glyphs, glyphs_in_string
+from diffenator2.utils import string_coords_to_dict, re_filter_characters, characters_in_string
 from diffenator2.font import DFont
 from diffenator2.matcher import FontMatcher
 from pkg_resources import resource_filename
@@ -38,15 +38,15 @@ class DiffFonts:
     def diff_words(self):
         self.glyph_diff = test_fonts(self.old_font, self.new_font, threshold=self.threshold)
 
-    def filter_glyphs(self, glyphs):
+    def filter_characters(self, characters):
         diff_words = self.glyph_diff["words"]
         for cat in diff_words:
-            diff_words[cat] = [i for i in diff_words[cat] if glyphs_in_string(i.string, glyphs)]
+            diff_words[cat] = [i for i in diff_words[cat] if characters_in_string(i.string, characters)]
         
         diff_glyphs = self.glyph_diff["glyphs"]
-        diff_glyphs.new = [g for g in diff_glyphs.new if glyphs_in_string(g.string, glyphs)]
-        diff_glyphs.missing = [g for g in diff_glyphs.missing if glyphs_in_string(g.string, glyphs)]
-        diff_glyphs.modified = [g for g in diff_glyphs.modified if glyphs_in_string(g.string, glyphs)]
+        diff_glyphs.new = [g for g in diff_glyphs.new if characters_in_string(g.string, characters)]
+        diff_glyphs.missing = [g for g in diff_glyphs.missing if characters_in_string(g.string, characters)]
+        diff_glyphs.modified = [g for g in diff_glyphs.modified if characters_in_string(g.string, characters)]
 
     def to_html(self, templates, out):
         diffenator_report(self, templates, dst=out)
@@ -67,7 +67,7 @@ def main():
     )
     parser.add_argument("--coords", "-c", default={})
     parser.add_argument("--threshold", "-t", default=THRESHOLD, type=float)
-    parser.add_argument("--glyphs", "-g", default=".*")
+    parser.add_argument("--characters", "-ch", default=".*")
     parser.add_argument("--out", "-o", default="out", help="Output html path")
     args = parser.parse_args()
 
@@ -84,8 +84,8 @@ def main():
     if args.user_wordlist:
         diff.diff_strings(args.user_wordlist)
     
-    glyphs = re_filter_glyphs(new_font, args.glyphs)
-    diff.filter_glyphs(glyphs)
+    characters = re_filter_characters(new_font, args.characters)
+    diff.filter_characters(characters)
     diff.to_html(args.template, args.out)
 
 

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -6,7 +6,7 @@ from fontTools.ttLib import TTFont
 import os
 import shutil
 from diffenator2.template_elements import CSSFontStyle, CSSFontFace
-from diffenator2.utils import font_sample_text, glyphs_in_string
+from diffenator2.utils import font_sample_text, characters_in_string
 from glyphsets import GFTestData
 import re
 
@@ -82,32 +82,32 @@ def diffenator_font_style(dfont, suffix=""):
     )
 
 
-def filtered_font_sample_text(ttFont, glyphs):
+def filtered_font_sample_text(ttFont, characters):
     sample_text = font_sample_text(ttFont)
-    sample_text = [w for w in sample_text if glyphs_in_string(w, glyphs)]
+    sample_text = [w for w in sample_text if characters_in_string(w, characters)]
     return " ".join(sample_text)
 
 
-def proof_rendering(styles, templates, dst="out", filter_styles=None, glyphs=set(), pt_size=20):
+def proof_rendering(styles, templates, dst="out", filter_styles=None, characters=set(), pt_size=20):
     ttFont = styles[0].font.ttFont
     font_faces = set(style.font.css_font_face for style in styles)
     font_styles = [style.css_font_style for style in styles]
-    sample_text = filtered_font_sample_text(ttFont, glyphs)
+    sample_text = filtered_font_sample_text(ttFont, characters)
     test_strings = GFTestData.test_strings_in_font(ttFont)
-    glyphs = [chr(c) for c in ttFont.getBestCmap()]
+    characters = [chr(c) for c in ttFont.getBestCmap()]
     _package(
         templates,
         dst,
         font_faces=font_faces,
         font_styles=font_styles,
         sample_text=sample_text,
-        glyphs=glyphs,
+        characters=characters,
         test_strings=test_strings,
         pt_size=pt_size,
     )
 
 
-def diff_rendering(matcher, templates, dst="out", filter_styles=None, glyphs=set(), pt_size=20):
+def diff_rendering(matcher, templates, dst="out", filter_styles=None, characters=set(), pt_size=20):
     ttFont = matcher.old_styles[0].font.ttFont
     font_faces_old = set(style.font.css_font_face for style in matcher.old_styles)
     font_styles_old = [style.css_font_style for style in matcher.old_styles]
@@ -115,9 +115,9 @@ def diff_rendering(matcher, templates, dst="out", filter_styles=None, glyphs=set
     font_faces_new = set(style.font.css_font_face for style in matcher.new_styles)
     font_styles_new = [style.css_font_style for style in matcher.new_styles]
 
-    sample_text=filtered_font_sample_text(ttFont, glyphs)
+    sample_text=filtered_font_sample_text(ttFont, characters)
     test_strings = GFTestData.test_strings_in_font(ttFont)
-    glyphs = [chr(c) for c in ttFont.getBestCmap()]
+    characters = [chr(c) for c in ttFont.getBestCmap()]
     _package(
         templates,
         dst,
@@ -127,7 +127,7 @@ def diff_rendering(matcher, templates, dst="out", filter_styles=None, glyphs=set
         font_styles_new=font_styles_new,
         include_ui=True,
         sample_text=sample_text,
-        glyphs=glyphs,
+        characters=characters,
         test_strings=test_strings,
         pt_size=pt_size,
     )

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -6,7 +6,7 @@ from fontTools.ttLib import TTFont
 import os
 import shutil
 from diffenator2.template_elements import CSSFontStyle, CSSFontFace
-from diffenator2.utils import font_sample_text
+from diffenator2.utils import font_sample_text, glyphs_in_string
 from glyphsets import GFTestData
 import re
 
@@ -82,11 +82,17 @@ def diffenator_font_style(dfont, suffix=""):
     )
 
 
-def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20):
+def filtered_font_sample_text(ttFont, glyphs):
+    sample_text = font_sample_text(ttFont)
+    sample_text = [w for w in sample_text if glyphs_in_string(w, glyphs)]
+    return " ".join(sample_text)
+
+
+def proof_rendering(styles, templates, dst="out", filter_styles=None, glyphs=set(), pt_size=20):
     ttFont = styles[0].font.ttFont
     font_faces = set(style.font.css_font_face for style in styles)
     font_styles = [style.css_font_style for style in styles]
-    sample_text = " ".join(font_sample_text(ttFont))
+    sample_text = filtered_font_sample_text(ttFont, glyphs)
     test_strings = GFTestData.test_strings_in_font(ttFont)
     glyphs = [chr(c) for c in ttFont.getBestCmap()]
     _package(
@@ -101,7 +107,7 @@ def proof_rendering(styles, templates, dst="out", filter_styles=None, pt_size=20
     )
 
 
-def diff_rendering(matcher, templates, dst="out", filter_styles=None, pt_size=20):
+def diff_rendering(matcher, templates, dst="out", filter_styles=None, glyphs=set(), pt_size=20):
     ttFont = matcher.old_styles[0].font.ttFont
     font_faces_old = set(style.font.css_font_face for style in matcher.old_styles)
     font_styles_old = [style.css_font_style for style in matcher.old_styles]
@@ -109,7 +115,7 @@ def diff_rendering(matcher, templates, dst="out", filter_styles=None, pt_size=20
     font_faces_new = set(style.font.css_font_face for style in matcher.new_styles)
     font_styles_new = [style.css_font_style for style in matcher.new_styles]
 
-    sample_text = " ".join(font_sample_text(ttFont))
+    sample_text=filtered_font_sample_text(ttFont, glyphs)
     test_strings = GFTestData.test_strings_in_font(ttFont)
     glyphs = [chr(c) for c in ttFont.getBestCmap()]
     _package(

--- a/src/diffenator2/html.py
+++ b/src/diffenator2/html.py
@@ -94,7 +94,7 @@ def proof_rendering(styles, templates, dst="out", filter_styles=None, characters
     font_styles = [style.css_font_style for style in styles]
     sample_text = filtered_font_sample_text(ttFont, characters)
     test_strings = GFTestData.test_strings_in_font(ttFont)
-    characters = [chr(c) for c in ttFont.getBestCmap()]
+    characters = characters or [chr(c) for c in ttFont.getBestCmap()]
     _package(
         templates,
         dst,
@@ -117,7 +117,7 @@ def diff_rendering(matcher, templates, dst="out", filter_styles=None, characters
 
     sample_text=filtered_font_sample_text(ttFont, characters)
     test_strings = GFTestData.test_strings_in_font(ttFont)
-    characters = [chr(c) for c in ttFont.getBestCmap()]
+    characters = characters or [chr(c) for c in ttFont.getBestCmap()]
     _package(
         templates,
         dst,

--- a/src/diffenator2/templates/diffbrowsers_glyphs.html
+++ b/src/diffenator2/templates/diffbrowsers_glyphs.html
@@ -23,8 +23,8 @@
       <div class="box">
 	<div class="box-title">{{ font_class.class_name }} {{ pt_size }}pt</div>
 	  <span class="{{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">
-	    {% for glyph in glyphs %}
-	      <div class="cell">{{ glyph }}</div>
+	    {% for character in characters %}
+	      <div class="cell">{{ character }}</div>
 	    {% endfor %}
           </span>
        </div>

--- a/src/diffenator2/utils.py
+++ b/src/diffenator2/utils.py
@@ -25,6 +25,7 @@ import os
 from io import BytesIO
 from fontTools.ttLib import TTFont
 from zipfile import ZipFile
+import re
 
 
 def dict_coords_to_string(coords: dict[str, float]) -> str:
@@ -177,3 +178,12 @@ def font_family_name(ttFont, suffix=""):
 def partition(items, size):
     """partition([1,2,3,4,5,6], 2) --> [[1,2],[3,4],[5,6]]"""
     return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def re_filter_glyphs(font, pattern):
+    glyphs_in_font = set(chr(g) for g in font.ttFont.getBestCmap())
+    return set(g for g in glyphs_in_font if re.search(pattern, g))
+
+
+def glyphs_in_string(string, glyphs):
+    return all(g in glyphs for g in string)

--- a/src/diffenator2/utils.py
+++ b/src/diffenator2/utils.py
@@ -180,10 +180,10 @@ def partition(items, size):
     return [items[i : i + size] for i in range(0, len(items), size)]
 
 
-def re_filter_glyphs(font, pattern):
-    glyphs_in_font = set(chr(g) for g in font.ttFont.getBestCmap())
-    return set(g for g in glyphs_in_font if re.search(pattern, g))
+def re_filter_characters(font, pattern):
+    characters_in_font = set(chr(g) for g in font.ttFont.getBestCmap())
+    return set(g for g in characters_in_font if re.search(pattern, g))
 
 
-def glyphs_in_string(string, glyphs):
-    return all(g in glyphs for g in string)
+def characters_in_string(string, characters):
+    return all(g in characters for g in string)

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -3,16 +3,16 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size -g "\$glyphs" --imgs --filter-styles \$
+      \$styles -o \$out -pt \$pt_size -ch "\$characters" --imgs --filter-styles \$
       "\$filters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs"
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs" --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -23,7 +23,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
   filters = Medium|ExtraBold
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -32,7 +32,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -41,5 +41,5 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=500.0

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -3,14 +3,16 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size --imgs --filter-styles "\$filters"
+      \$styles -o \$out -pt \$pt_size -g "\$glyphs" --imgs --filter-styles \$
+      "\$filters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -21,6 +23,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
   filters = Medium|ExtraBold
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -29,6 +32,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
+  glyphs = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -37,4 +41,5 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
+  glyphs = .*
   coords = wght=500.0

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -3,14 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size --imgs
+      \$styles -o \$out -pt \$pt_size -g "\$glyphs" --imgs
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -21,6 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -28,6 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.9
+  glyphs = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -36,6 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.9
+  glyphs = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -44,6 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
+  glyphs = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -52,6 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
+  glyphs = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -60,6 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.9
+  glyphs = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -68,4 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.9
+  glyphs = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -3,15 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size -g "\$glyphs" --imgs
+      \$styles -o \$out -pt \$pt_size -ch "\$characters" --imgs
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs"
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs" --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -22,7 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -30,7 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -39,7 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -48,7 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -57,7 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -66,7 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -75,5 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -3,14 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size
+      \$styles -o \$out -pt \$pt_size -g "\$glyphs"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -21,6 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -28,6 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.9
+  glyphs = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -36,6 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.9
+  glyphs = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -44,6 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
+  glyphs = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -52,6 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
+  glyphs = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -60,6 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.9
+  glyphs = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -68,4 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.9
+  glyphs = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -3,15 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size -g "\$glyphs"
+      \$styles -o \$out -pt \$pt_size -ch "\$characters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs"
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs" --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -22,7 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -30,7 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -39,7 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -48,7 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -57,7 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -66,7 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -75,5 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.9
-  glyphs = .*
+  characters = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-threshold.txt
+++ b/tests/data/ninja_files/diff-threshold.txt
@@ -3,14 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size
+      \$styles -o \$out -pt \$pt_size -g "\$glyphs"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out \$
-      --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
+      "\$glyphs" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -21,6 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -28,6 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.01
+  glyphs = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -36,6 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.01
+  glyphs = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -44,6 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.01
+  glyphs = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -52,6 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.01
+  glyphs = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -60,6 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.01
+  glyphs = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -68,4 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.01
+  glyphs = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-threshold.txt
+++ b/tests/data/ninja_files/diff-threshold.txt
@@ -3,15 +3,15 @@
 # Build Hinting docs
 rule diffbrowsers
   command = _diffbrowsers diff -fb \$fonts_before -fa \$fonts_after -s \$
-      \$styles -o \$out -pt \$pt_size -g "\$glyphs"
+      \$styles -o \$out -pt \$pt_size -ch "\$characters"
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs"
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -g \$
-      "\$glyphs" --coords \$coords
+  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
+      "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -22,7 +22,7 @@ build out/diffbrowsers: diffbrowsers
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
 build out/Black: diffenator-inst
   font_before = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
@@ -30,7 +30,7 @@ build out/Black: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Black
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -39,7 +39,7 @@ build out/Bold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Bold
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -48,7 +48,7 @@ build out/ExtraBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = ExtraBold
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -57,7 +57,7 @@ build out/Medium: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Medium
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -66,7 +66,7 @@ build out/Regular: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = Regular
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -75,5 +75,5 @@ build out/SemiBold: diffenator-inst
       ".*/tests/data/MavenPro\[wght\].subset.mod.ttf"
   out = SemiBold
   threshold = 0.01
-  glyphs = .*
+  characters = .*
   coords = wght=600.0

--- a/tests/data/ninja_files/proof-filter-styles.txt
+++ b/tests/data/ninja_files/proof-filter-styles.txt
@@ -1,8 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
-      "\$glyphs" --imgs --filter-styles "\$filters"
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -ch \$
+      "\$characters" --imgs --filter-styles "\$filters"
 
 # Build rules
 build out: proofing
@@ -11,6 +11,6 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
   imgs = True
   filters = Medium|Bold

--- a/tests/data/ninja_files/proof-filter-styles.txt
+++ b/tests/data/ninja_files/proof-filter-styles.txt
@@ -1,8 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size --imgs \$
-      --filter-styles "\$filters"
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
+      "\$glyphs" --imgs --filter-styles "\$filters"
 
 # Build rules
 build out: proofing
@@ -11,5 +11,6 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
   imgs = True
   filters = Medium|Bold

--- a/tests/data/ninja_files/proof-imgs.txt
+++ b/tests/data/ninja_files/proof-imgs.txt
@@ -1,7 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size --imgs
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
+      "\$glyphs" --imgs
 
 # Build rules
 build out: proofing
@@ -10,4 +11,5 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*
   imgs = True

--- a/tests/data/ninja_files/proof-imgs.txt
+++ b/tests/data/ninja_files/proof-imgs.txt
@@ -1,8 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
-      "\$glyphs" --imgs
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -ch \$
+      "\$characters" --imgs
 
 # Build rules
 build out: proofing
@@ -11,5 +11,5 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*
   imgs = True

--- a/tests/data/ninja_files/proof-standard.txt
+++ b/tests/data/ninja_files/proof-standard.txt
@@ -1,7 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
+      "\$glyphs"
 
 # Build rules
 build out: proofing
@@ -10,3 +11,4 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
+  glyphs = .*

--- a/tests/data/ninja_files/proof-standard.txt
+++ b/tests/data/ninja_files/proof-standard.txt
@@ -1,8 +1,8 @@
 # Rules
 
 rule proofing
-  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -g \$
-      "\$glyphs"
+  command = _diffbrowsers proof \$fonts -s \$styles -o \$out -pt \$pt_size -ch \$
+      "\$characters"
 
 # Build rules
 build out: proofing
@@ -11,4 +11,4 @@ build out: proofing
   styles = instances
   out = out/diffbrowsers
   pt_size = 20
-  glyphs = .*
+  characters = .*

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -99,12 +99,12 @@ def test_diffenator_threshold(fp_before, fp_after, threshold, has, missing):
         (mavenpro_vf, "diff", "[an]{1,2}", ['style="font-size: 14pt">an</div>'], []),
     ]
 )
-def test_diffbrowsers_filter_glyphs(fp, cmd, pattern, has, missing):
+def test_diffbrowsers_filter_characters(fp, cmd, pattern, has, missing):
     with tempfile.TemporaryDirectory() as tmp_dir:
         if cmd == "proof":
-            subprocess.run(["_diffbrowsers", cmd, fp, "-g", pattern, "-o", tmp_dir])
+            subprocess.run(["_diffbrowsers", cmd, fp, "-c", pattern, "-o", tmp_dir])
         elif cmd == "diff":
-            subprocess.run(["_diffbrowsers", cmd, "-fb", fp, "-fa", fp, "-g", pattern, "-o", tmp_dir])
+            subprocess.run(["_diffbrowsers", cmd, "-fb", fp, "-fa", fp, "-c", pattern, "-o", tmp_dir])
 
         with open(os.path.join(tmp_dir, "diffbrowsers_text.html"), "r", encoding="utf8") as doc:
             report = doc.read()
@@ -122,9 +122,9 @@ def test_diffbrowsers_filter_glyphs(fp, cmd, pattern, has, missing):
         (mavenpro_vf, mavenpro_vf_mod, "n|t", [], ["LATIN SMALL LETTER A"]),
     ]
 )
-def test_diffenator_filter_glyphs(fp_before, fp_after, pattern, has, missing):
+def test_diffenator_filter_characters(fp_before, fp_after, pattern, has, missing):
     with tempfile.TemporaryDirectory() as tmp_dir:
-        subprocess.run(["_diffenator", fp_before, fp_after, "-o", tmp_dir, "-g", pattern])
+        subprocess.run(["_diffenator", fp_before, fp_after, "-o", tmp_dir, "-ch", pattern])
         with open(os.path.join(tmp_dir, "diffenator.html"), "r", encoding="utf8") as doc:
             report = doc.read()
             for string in has:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -113,3 +113,22 @@ def test_diffbrowsers_filter_glyphs(fp, cmd, pattern, has, missing):
             
             for string in missing:
                 assert string not in report
+
+
+@pytest.mark.parametrize(
+    "fp_before, fp_after, pattern, has, missing",
+    [
+        (mavenpro_vf, mavenpro_vf_mod, ".*", ["LATIN SMALL LETTER A"], []),
+        (mavenpro_vf, mavenpro_vf_mod, "n|t", [], ["LATIN SMALL LETTER A"]),
+    ]
+)
+def test_diffenator_filter_glyphs(fp_before, fp_after, pattern, has, missing):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        subprocess.run(["_diffenator", fp_before, fp_after, "-o", tmp_dir, "-g", pattern])
+        with open(os.path.join(tmp_dir, "diffenator.html"), "r", encoding="utf8") as doc:
+            report = doc.read()
+            for string in has:
+                assert string in report
+
+            for string in missing:
+                assert string not in report

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -88,3 +88,28 @@ def test_diffenator_threshold(fp_before, fp_after, threshold, has, missing):
             
             for string in missing:
                 assert string not in report
+
+
+@pytest.mark.parametrize(
+    "fp, cmd, pattern, has, missing",
+    [
+        (mavenpro_vf, "proof", ".*", ['style="font-size: 14pt">an tan</div>'], []),
+        (mavenpro_vf, "proof", "[an]{1,2}", ['style="font-size: 14pt">an</div>'], []),
+        (mavenpro_vf, "diff", ".*", ['style="font-size: 14pt">an tan</div>'], []),
+        (mavenpro_vf, "diff", "[an]{1,2}", ['style="font-size: 14pt">an</div>'], []),
+    ]
+)
+def test_diffbrowsers_filter_glyphs(fp, cmd, pattern, has, missing):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        if cmd == "proof":
+            subprocess.run(["_diffbrowsers", cmd, fp, "-g", pattern, "-o", tmp_dir])
+        elif cmd == "diff":
+            subprocess.run(["_diffbrowsers", cmd, "-fb", fp, "-fa", fp, "-g", pattern, "-o", tmp_dir])
+
+        with open(os.path.join(tmp_dir, "diffbrowsers_text.html"), "r", encoding="utf8") as doc:
+            report = doc.read()
+            for string in has:
+                assert string in report
+            
+            for string in missing:
+                assert string not in report

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import tempfile
 import pytest
 import os
 from io import BytesIO
+from . import *
 
 
 def test_download_google_fonts_family_to_file():
@@ -36,3 +37,25 @@ def test_download_latest_github_release():
             github_token=os.environ.get("GH_TOKEN")
         )
         assert len(files) != 0
+
+
+def test_glyphs_in_string():
+    from diffenator2.utils import glyphs_in_string
+
+    assert glyphs_in_string("hello", set(["h", "e", "l", "o"]))
+    assert not glyphs_in_string("hello", set(["e", "l", "o"]))
+
+
+@pytest.mark.parametrize(
+    """fp,pattern,expected""",
+    [
+        (mavenpro_vf, ".*", {'n', ' ', 't', 'a'}),
+        (mavenpro_vf, "t|a", {"t", "a"}),
+        (mavenpro_vf, "\W", {" "})
+    ]
+)
+def test_re_filter_glyphs(fp, pattern, expected):
+    from diffenator2.utils import re_filter_glyphs
+    from diffenator2.font import DFont
+    font = DFont(fp)
+    assert re_filter_glyphs(font, pattern) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,10 +40,10 @@ def test_download_latest_github_release():
 
 
 def test_glyphs_in_string():
-    from diffenator2.utils import glyphs_in_string
+    from diffenator2.utils import characters_in_string
 
-    assert glyphs_in_string("hello", set(["h", "e", "l", "o"]))
-    assert not glyphs_in_string("hello", set(["e", "l", "o"]))
+    assert characters_in_string("hello", set(["h", "e", "l", "o"]))
+    assert not characters_in_string("hello", set(["e", "l", "o"]))
 
 
 @pytest.mark.parametrize(
@@ -55,7 +55,7 @@ def test_glyphs_in_string():
     ]
 )
 def test_re_filter_glyphs(fp, pattern, expected):
-    from diffenator2.utils import re_filter_glyphs
+    from diffenator2.utils import re_filter_characters
     from diffenator2.font import DFont
     font = DFont(fp)
-    assert re_filter_glyphs(font, pattern) == expected
+    assert re_filter_characters(font, pattern) == expected


### PR DESCRIPTION
This PR allows you to filter which glyphs you want to see. Simply supply a regex string for the glyps you want to see e.g


`diffenator2 proof font1.ttf --glyphs "[!-~]"`

Above example will only check the ascii set. 
