### PR TITLE
Only compute the TTJ on demand

### DIFF
--- a/src/diffenator2/font.py
+++ b/src/diffenator2/font.py
@@ -62,12 +62,16 @@ class DFont:
         with open(path, "rb") as fontfile:
             fontdata = fontfile.read()
         self.hbFont: hb.Font = hb.Font(hb.Face(fontdata))
-        self.jFont = jfont.TTJ(self.ttFont)
 
         self.css_font_face = CSSFontFace(self.ttFont, self.suffix)
 
         self.font_size: int = font_size
         self.set_font_size(self.font_size)
+
+    @property
+    @lru_cache()
+    def jFont(self):
+        return jfont.TTJ(self.ttFont)
 
     @lru_cache()
     def is_color(self):


### PR DESCRIPTION
Currently we call `DFont()` on all the fonts both in the "orchestration" command (diffenator2) and also the ninja command (_diffbrowsers). Whenever we initialise a `DFont` object, we run `self.jFont = jfont.TTJ(self.ttFont)` to decompile the font into a JSON representation. This takes quite a lot of time, and `diffenator2` doesn't even use that information! If you're running `diffenator2 proof` (which doesn't use the TTJ object either), then you decompile the font *twice* for no benefit.

Before this PR:

```
% time diffenator2 proof fonts/NotoSansMono/unhinted/ttf/NotoSansMono-*
diffenator2 proof   48.72s user 1.32s system 99% cpu 50.288 total
```

After this PR:

```
% time diffenator2 proof fonts/NotoSansMono/unhinted/ttf/NotoSansMono-*
diffenator2 proof   9.38s user 0.77s system 99% cpu 10.204 total
```
