### PR TITLE
Only add click handler to nodes in the difftable

### DIFF
--- a/src/diffenator2/templates/diffenator.html
+++ b/src/diffenator2/templates/diffenator.html
@@ -142,7 +142,7 @@
 	}
 	$(function() {
 		$("#difftable").append(render(fontdiff, true).children())
-		$(".node").on("click", function(event){ $(this).children().toggle(); event.stopPropagation() })
+		$("#difftable .node").on("click", function(event){ $(this).children().toggle(); event.stopPropagation() })
 	});
 
 function wordBreaks() {


### PR DESCRIPTION
We use the `node` class for all sorts of things. Without this patch, a diff of Noto Serif CJK failed because there were *millions* of nodes, most of which did not want a click handler attached.