### PR TITLE
More options

### DIFF
--- a/src/diffenator2/__init__.py
+++ b/src/diffenator2/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import os
 from ninja.ninja_syntax import Writer
+from diffenator2.renderer import FONT_SIZE
 from diffenator2.utils import dict_coords_to_string
 from diffenator2.font import DFont, get_font_styles
 from diffenator2.utils import partition
@@ -102,6 +103,9 @@ def ninja_diff(
     filter_styles: str = "",
     pt_size: int = 20,
     threshold: float = THRESHOLD,
+    precision: int = FONT_SIZE,
+    no_words: bool = False,
+    no_tables: bool = False,
 ):
     if not os.path.exists(out):
         os.mkdir(out)
@@ -120,6 +124,9 @@ def ninja_diff(
             filter_styles,
             pt_size,
             threshold=threshold,
+            precision=precision,
+            no_words=no_words,
+            no_tables=no_tables,
         )
         return
 
@@ -152,6 +159,9 @@ def ninja_diff(
             filter_styles,
             pt_size,
             threshold=threshold,
+            precision=precision,
+            no_words=no_words,
+            no_tables=no_tables,
         )
 
 def _ninja_diff(
@@ -167,6 +177,9 @@ def _ninja_diff(
     filter_styles: str = "",
     pt_size: int = 20,
     threshold: float = THRESHOLD,
+    precision: int = FONT_SIZE,
+    no_words: bool = False,
+    no_tables: bool = False,
 ):
     w = Writer(open(NINJA_BUILD_FILE, "w", encoding="utf8"))
     # Setup rules
@@ -184,9 +197,13 @@ def _ninja_diff(
     w.newline()
 
     w.comment("Run diffenator VF")
-    diff_cmd = f'_diffenator $font_before $font_after -t $threshold -o $out -ch "$characters"'
+    diff_cmd = f'_diffenator $font_before $font_after --font-size $precision -t $threshold -o $out -ch "$characters"'
     if user_wordlist:
         diff_cmd += ' --user-wordlist "$user_wordlist"'
+    if no_words:
+        diff_cmd += ' --no-words'
+    if no_tables:
+        diff_cmd += ' --no-tables'
     diff_inst_cmd = diff_cmd + " --coords $coords"
     w.rule("diffenator", diff_cmd)
     w.rule("diffenator-inst", diff_inst_cmd)
@@ -221,6 +238,7 @@ def _ninja_diff(
                 out=style,
                 threshold=str(threshold),
                 characters=characters,
+                precision=str(precision),
             )
             if user_wordlist:
                 diff_variables["user_wordlist"] = user_wordlist

--- a/src/diffenator2/__main__.py
+++ b/src/diffenator2/__main__.py
@@ -5,6 +5,7 @@ import os
 from diffenator2 import ninja_diff, ninja_proof, THRESHOLD, NINJA_BUILD_FILE
 from diffenator2.font import DFont
 from diffenator2.html import build_index_page
+from diffenator2.renderer import FONT_SIZE
 
 
 
@@ -47,6 +48,9 @@ def main(**kwargs):
         diff_parser.add_argument("--fonts-after", "-fa", nargs="+", required=True)
         diff_parser.add_argument("--no-diffenator", default=False, action="store_true")
         diff_parser.add_argument("--threshold", "-t", type=float, default=THRESHOLD)
+        diff_parser.add_argument("--precision", default=FONT_SIZE)
+        diff_parser.add_argument("--no-tables", action="store_true", help="Skip diffing font tables")
+        diff_parser.add_argument("--no-words", action="store_true", help="Skip diffing wordlists")
         args = parser.parse_args()
 
     if os.path.exists(NINJA_BUILD_FILE):
@@ -80,6 +84,9 @@ def main(**kwargs):
             filter_styles=args.filter_styles,
             pt_size=args.pt_size,
             threshold=args.threshold,
+            precision=args.precision,
+            no_words=args.no_words,
+            no_tables=args.no_tables,
         )
     else:
         raise NotImplementedError(f"{args.command} not supported")

--- a/src/diffenator2/_diffenator.py
+++ b/src/diffenator2/_diffenator.py
@@ -35,7 +35,7 @@ class DiffFonts:
         skip = frozenset(["diff_strings", "diff_all"])
         diff_funcs = [f for f in dir(self) if f.startswith("diff_") if f not in skip]
         for f in diff_funcs:
-            getattr(self,f)()
+            getattr(self, f)()
 
     def diff_tables(self):
         if not self.do_tables:
@@ -64,12 +64,22 @@ class DiffFonts:
     def filter_characters(self, characters):
         diff_words = self.glyph_diff["words"]
         for cat in diff_words:
-            diff_words[cat] = [i for i in diff_words[cat] if characters_in_string(i.string, characters)]
-        
+            diff_words[cat] = [
+                i for i in diff_words[cat] if characters_in_string(i.string, characters)
+            ]
+
         diff_glyphs = self.glyph_diff["glyphs"]
-        diff_glyphs.new = [g for g in diff_glyphs.new if characters_in_string(g.string, characters)]
-        diff_glyphs.missing = [g for g in diff_glyphs.missing if characters_in_string(g.string, characters)]
-        diff_glyphs.modified = [g for g in diff_glyphs.modified if characters_in_string(g.string, characters)]
+        diff_glyphs.new = [
+            g for g in diff_glyphs.new if characters_in_string(g.string, characters)
+        ]
+        diff_glyphs.missing = [
+            g for g in diff_glyphs.missing if characters_in_string(g.string, characters)
+        ]
+        diff_glyphs.modified = [
+            g
+            for g in diff_glyphs.modified
+            if characters_in_string(g.string, characters)
+        ]
 
     def to_html(self, templates, out):
         diffenator_report(self, templates, dst=out)

--- a/src/diffenator2/shape.py
+++ b/src/diffenator2/shape.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 # Hashing strategies for elements of a Harfbuzz buffer
 
+
 def gid_pos_hash(info, pos):
     return f"gid={info.codepoint}, pos={pos.position}<br>"
 
@@ -36,8 +37,6 @@ ot_to_html_lang = {
 }
 
 ot_to_dir = {None: "ltr", "arab": "rlt", "hebr": "rtl"}
-
-
 
 
 @dataclass
@@ -164,8 +163,14 @@ def test_words(
 
         # split sentences into individual script segments. This mimmics the
         # same behaviour as dtp apps, web browsers etc
-        for segment, script, _, _, in textSegments(word.string)[0]:
-
+        for (
+            segment,
+            script,
+            _,
+            _,
+        ) in textSegments(
+            word.string
+        )[0]:
             if any(c.string in segment for c in skip_glyphs):
                 continue
 
@@ -175,7 +180,10 @@ def test_words(
             buf_b = differ.renderer_b.shape(segment)
             word_b = Word.from_buffer(segment, buf_b)
 
-            gid_hashes = [hash_func(i, j) for i, j in zip(buf_b.glyph_infos, buf_b.glyph_positions)]
+            gid_hashes = [
+                hash_func(i, j)
+                for i, j in zip(buf_b.glyph_infos, buf_b.glyph_positions)
+            ]
             # I'm not entirely convinced this is a valid test; but it seems to
             # work and speeds things up a lot...
             if all(gid_hash in seen_gids for gid_hash in gid_hashes):
@@ -185,7 +193,7 @@ def test_words(
             word_a = Word.from_buffer(segment, buf_a)
 
             # skip any words which cannot be shaped correctly
-            if any([g.codepoint == 0 for g in buf_a.glyph_infos+buf_b.glyph_infos]):
+            if any([g.codepoint == 0 for g in buf_a.glyph_infos + buf_b.glyph_infos]):
                 continue
 
             pc, diff_map = differ.diff(segment)
@@ -210,4 +218,3 @@ def test_words(
                     )
                 )
     return [w[1] for w in sorted(res, key=lambda k: k[0], reverse=True)]
-

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -8,11 +8,11 @@ rule diffbrowsers
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters"
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters" --coords \$coords
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -33,6 +33,7 @@ build out/ExtraBold: diffenator-inst
   out = ExtraBold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -42,4 +43,5 @@ build out/Medium: diffenator-inst
   out = Medium
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=500.0

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -7,11 +7,11 @@ rule diffbrowsers
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters"
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters" --coords \$coords
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -31,6 +31,7 @@ build out/Black: diffenator-inst
   out = Black
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -40,6 +41,7 @@ build out/Bold: diffenator-inst
   out = Bold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -49,6 +51,7 @@ build out/ExtraBold: diffenator-inst
   out = ExtraBold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -58,6 +61,7 @@ build out/Medium: diffenator-inst
   out = Medium
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -67,6 +71,7 @@ build out/Regular: diffenator-inst
   out = Regular
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -76,4 +81,5 @@ build out/SemiBold: diffenator-inst
   out = SemiBold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -7,11 +7,11 @@ rule diffbrowsers
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters"
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters" --coords \$coords
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -31,6 +31,7 @@ build out/Black: diffenator-inst
   out = Black
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -40,6 +41,7 @@ build out/Bold: diffenator-inst
   out = Bold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -49,6 +51,7 @@ build out/ExtraBold: diffenator-inst
   out = ExtraBold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -58,6 +61,7 @@ build out/Medium: diffenator-inst
   out = Medium
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -67,6 +71,7 @@ build out/Regular: diffenator-inst
   out = Regular
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -76,4 +81,5 @@ build out/SemiBold: diffenator-inst
   out = SemiBold
   threshold = 0.9
   characters = .*
+  precision = 28
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-threshold.txt
+++ b/tests/data/ninja_files/diff-threshold.txt
@@ -7,11 +7,11 @@ rule diffbrowsers
 
 # Run diffenator VF
 rule diffenator
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters"
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters"
 rule diffenator-inst
-  command = _diffenator \$font_before \$font_after -t \$threshold -o \$out -ch \$
-      "\$characters" --coords \$coords
+  command = _diffenator \$font_before \$font_after --font-size \$precision -t \$
+      \$threshold -o \$out -ch "\$characters" --coords \$coords
 
 # Build rules
 build out/diffbrowsers: diffbrowsers
@@ -31,6 +31,7 @@ build out/Black: diffenator-inst
   out = Black
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=900.0
 build out/Bold: diffenator-inst
   font_before = \$
@@ -40,6 +41,7 @@ build out/Bold: diffenator-inst
   out = Bold
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=700.0
 build out/ExtraBold: diffenator-inst
   font_before = \$
@@ -49,6 +51,7 @@ build out/ExtraBold: diffenator-inst
   out = ExtraBold
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=800.0
 build out/Medium: diffenator-inst
   font_before = \$
@@ -58,6 +61,7 @@ build out/Medium: diffenator-inst
   out = Medium
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=500.0
 build out/Regular: diffenator-inst
   font_before = \$
@@ -67,6 +71,7 @@ build out/Regular: diffenator-inst
   out = Regular
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=400.0
 build out/SemiBold: diffenator-inst
   font_before = \$
@@ -76,4 +81,5 @@ build out/SemiBold: diffenator-inst
   out = SemiBold
   threshold = 0.01
   characters = .*
+  precision = 28
   coords = wght=600.0

--- a/tests/data/ninja_files/proof-filter-styles.txt
+++ b/tests/data/ninja_files/proof-filter-styles.txt
@@ -6,7 +6,7 @@ rule proofing
 
 # Build rules
 build out: proofing
-  fonts = $
+  fonts = \$
       ".*/tests/data/MavenPro\[wght\].subset.ttf"
   styles = instances
   out = out/diffbrowsers

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -4,6 +4,11 @@ from diffenator2.font import DFont
 import re
 
 
+def assert_match(expected_fp):
+    with open(expected_fp) as expected, open("build.ninja") as current:
+        for ix, (exp, cur) in enumerate(zip(expected.readlines(), current.readlines())):
+            assert re.search(exp, cur), "Expected: %sFound %s at line %i of %s" % (exp, cur, ix, expected_fp)
+
 
 @pytest.mark.parametrize(
     """kwargs,expected_fp""",
@@ -50,11 +55,7 @@ def test_run_ninja_diff(kwargs, expected_fp):
     from diffenator2 import _ninja_diff
 
     _ninja_diff(**kwargs)
-
-    with open(expected_fp) as expected, open("build.ninja") as current:
-        exp = expected.read()
-        cur = current.read()
-        assert re.search(exp, cur)
+    assert_match(expected_fp)
 
 
 @pytest.mark.parametrize(
@@ -90,7 +91,4 @@ def test_run_ninja_proof(kwargs, expected_fp):
     from diffenator2 import _ninja_proof
 
     _ninja_proof(**kwargs)
-    with open(expected_fp) as expected, open("build.ninja") as current:
-        exp = expected.read()
-        cur = current.read()
-        assert re.search(exp, cur)
+    assert_match(expected_fp)


### PR DESCRIPTION
This adds:

* A `--precision` option to change the font size used when creating the renders for diffing. 
* A `--no-tables` option to skip generating the JFont table diff.
* A `--no-words` option to skip using the wordlists and just diff glyphs.

Also I turned on "run black on save" so some files got reformatted but that's not a bad thing.