### PR TITLE
fix proof views

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.7,<4.0"
 fontTools = { version = ">=4.37.3", extras = ["ufo"] }
 jinja2 = "*"
 Pillow = "*"
-glyphsets = ">=0.6.0"
+glyphsets = ">=0.6.5"
 uharfbuzz = "*"
 pyahocorasick = "*"
 selenium = ">=4.4.3"

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -79,8 +79,9 @@
         {% for section_title, strings in section.items() %}
             <div class="box">
                 <div class="box-title">{{ section_title }}</div>
-                {% for string in strings %}
-                    <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                {% for sentence in strings %}
+                    <div class="box-text {{ font_class.class_name }}" style="font-size: {{ pt_size }}pt" lang="{{ sentence['lang'] }}">
+                        {{ sentence["string"] }}</div>
                 {% endfor %}
             </div>
         {% endfor %}
@@ -98,8 +99,10 @@
             {% for section_title, strings in section.items() %}
                 <div class="box">
                     <div class="box-title">{{ section_title }}</div>
-                    {% for string in strings %}
-                        <div class="box-text {{ font_class.class_name }} box-text" style="font-size: {{ pt_size }}pt">{{ string }}</div>
+                    {% for sentence in strings %}
+                        <div class="box-text {{ font_class.class_name }} box-text" style="font-size: {{ pt_size }}pt" lang="{{ sentence['lang'] }}">
+                            {{ sentence["string"] }}
+                        </div>
                     {% endfor %}
                 </div>
             {% endfor %}


### PR DESCRIPTION
Currently, the proof is broken for views other than "line by line"

<img width="1432" alt="Screenshot 2023-11-08 at 10 45 46" src="https://github.com/googlefonts/diffenator2/assets/7525512/4a648ba6-6566-4d4d-84ea-dbfe1207cfe0">
