### PR TITLE
cli: add --characters-file

### DIFF
--- a/src/diffenator2/__main__.py
+++ b/src/diffenator2/__main__.py
@@ -25,7 +25,9 @@ def main(**kwargs):
             "--imgs", help="Generate images", action="store_true", default=False
         )
         universal_options_parser.add_argument("--filter-styles", default=None)
-        universal_options_parser.add_argument("--characters", "-ch", default=".*")
+        char_group = universal_options_parser.add_mutually_exclusive_group()
+        char_group.add_argument("--characters", "-ch", default=".*")
+        char_group.add_argument("--characters-file", "-chf")
         universal_options_parser.add_argument("--pt-size", "-pt", default=20)
         universal_options_parser.add_argument(
             "--styles", "-s", choices=("instances", "cross_product", "masters"),
@@ -52,6 +54,10 @@ def main(**kwargs):
         diff_parser.add_argument("--no-tables", action="store_true", help="Skip diffing font tables")
         diff_parser.add_argument("--no-words", action="store_true", help="Skip diffing wordlists")
         args = parser.parse_args()
+
+    if args.characters_file:
+        with open(args.characters_file, encoding="utf-8") as char_file:
+            args.characters = char_file.read()
 
     if os.path.exists(NINJA_BUILD_FILE):
         os.remove(NINJA_BUILD_FILE)

--- a/src/diffenator2/_diffenator.py
+++ b/src/diffenator2/_diffenator.py
@@ -101,7 +101,9 @@ def main():
     parser.add_argument("--coords", "-c", default={})
     parser.add_argument("--threshold", "-t", default=THRESHOLD, type=float)
     parser.add_argument("--font-size", "-pt", default=FONT_SIZE, type=int)
-    parser.add_argument("--characters", "-ch", default=".*")
+    char_group = parser.add_mutually_exclusive_group()
+    char_group.add_argument("--characters", "-ch", default=".*")
+    char_group.add_argument("--characters-file", "-chf")
     parser.add_argument("--no-words", action="store_true")
     parser.add_argument("--no-tables", action="store_true")
     parser.add_argument("--out", "-o", default="out", help="Output html path")
@@ -114,6 +116,10 @@ def main():
     matcher = FontMatcher([old_font], [new_font])
     matcher.diffenator(coords)
     matcher.upms()
+
+    if args.characters_file:
+        with open(args.characters_file, encoding="utf-8") as char_file:
+            args.characters = char_file.read()
 
     diff = DiffFonts(
         matcher,


### PR DESCRIPTION
This PR allows users to use a file containing a regex string to filter out characters.

@madig could you please test this (don't have a win machine to hand)? Here's you test string with the required mods.

```REGEX
[!"#$%&'\(\)*+,-.\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ'\[\\\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}~ ¡¢£¥§¨©ª«®¯°²³´¶·¸¹º»¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĊċČčĎďĐđĒēĖėĘęĚěĞğĠġĢģĦħĪīĮįİıĲĳĶķĹĺĻļĽľĿŁłŃńŅņŇňŊŋŌōŐőŒœŔŕŖŗŘřŚśŞşŠšŢţŤťŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžǍȘșȚțȷˆˇ˘˙˚˛˜˝ẀẁẂẃẄẅẞỲỳ –—‘’‚“”„•…‹›⁄⁰⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅₆₇₈₉€™−◌]
```

Fixes #88 

