### PR TITLE
diff tables: make glyf table diffs human readable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         # test on same versions as fonttools
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.10"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude: # Only test on the latest supported stable Python on macOS and Windows.
           - platform: macos-latest
-            python-version: 3.7
+            python-version: 3.10
           - platform: windows-latest
-            python-version: 3.7
+            python-version: 3.10
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ enable = true
 source = "git-tag"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 fontTools = { version = ">=4.37.3", extras = ["ufo"] }
 jinja2 = "*"
 Pillow = "*"

--- a/src/diffenator2/jfont.py
+++ b/src/diffenator2/jfont.py
@@ -212,7 +212,7 @@ def _TTJ(obj, root=None,depth=1):
     elif isinstance(obj, TTFont):
         if depth > 1:
             return None
-        return {k: _TTJ(obj[k], root) for k in obj.keys() if k not in ["loca"]}
+        return {k: _TTJ(obj[k], root) for k in obj.keys() if k not in ["loca", "GPOS", "GSUB", "GVAR"]}
     elif isinstance(obj, dict):
         return {k: _TTJ(v, root) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple, set)):

--- a/src/diffenator2/jfont.py
+++ b/src/diffenator2/jfont.py
@@ -260,7 +260,7 @@ class Diff:
             res[k] = self.clean(v)
             if res[k] == False or not res[k]:
                 res.pop(k)
-        if len(res) >= 133:
+        if len(res) >= 200:
             return {"error": (f"There are {len(res)} changes, check manually!", "")}
         return res
 

--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -106,11 +106,11 @@
             .header {
             font-weight: bold;
             }
-            .attrib-old{
+            .attr-before{
                 color: red;
                 cursor: text;
             }
-            .attrib-new{
+            .attr-after{
                 color: green;
                 cursor: text;
             }


### PR DESCRIPTION
Paths nodes and components are now visible.

<img width="574" alt="Screenshot 2023-11-28 at 15 55 08" src="https://github.com/googlefonts/diffenator2/assets/7525512/086c4d1b-9a29-4a21-a38b-b0c8fbbfbfb3">
