### PR TITLE
Adding autoSwitch for diff browsers proofer

### DIFF
--- a/src/diffenator2/templates/_base.html
+++ b/src/diffenator2/templates/_base.html
@@ -193,10 +193,16 @@
 
 	POSITION = "old"
 	fontToggle = document.getElementById("font-toggle")
-	function switchFonts() {
+	function switchFonts(isClickEvent) {
+
+    // when a click triggers the action stop autoSwitching
+    if (isClickEvent && autoSwitch) {
+        clearInterval(autoSwitch);
+    }
+
 	boxTitles = document.getElementsByClassName("box-title")
 	items = document.getElementsByClassName("box-text");
-	  
+
 	if (POSITION === "old") {
 	  POSITION = "new"
 	  for (item of boxTitles) {

--- a/src/diffenator2/templates/diffbrowsers_proofer.html
+++ b/src/diffenator2/templates/diffbrowsers_proofer.html
@@ -277,5 +277,9 @@ function setWidth() {
     }
 }
 
+const autoSwitch = setInterval(function () {
+    switchFonts();
+}, 1250);
+
 
 {% endblock %}


### PR DESCRIPTION
This enables the automatic switching of fonts (new vs old) every 1.25 secs.
This helps to compare the versions without clicking all the time.

If the user clicks the old/new button, then the switching stops.


Demo:
![ScreenRecording2024-01-30at11 39 00-ezgif com-video-to-gif-converter](https://github.com/googlefonts/diffenator2/assets/2414972/f96a2359-2de6-4b48-93ad-ad1420bc8eeb)

PS. I couldn't test it compiles the HTML properly, just added the snippets in the template