### PR TITLE
Upgrade fonttools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
         # test on same versions as fonttools
         python-version: ["3.10"]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        exclude: # Only test on the latest supported stable Python on macOS and Windows.
-          - platform: macos-latest
-            python-version: 3.10
-          - platform: windows-latest
-            python-version: 3.10
+        platform: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ source = "git-tag"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-fontTools = { version = ">=4.37.3", extras = ["ufo"] }
+fontTools = { version = ">=4.52.1", extras = ["ufo"] }
 jinja2 = "*"
 Pillow = "*"
 glyphsets = ">=0.6.5"

--- a/src/diffenator2/jfont.py
+++ b/src/diffenator2/jfont.py
@@ -166,11 +166,6 @@ def serialise_glyph(obj, root):
             f"Component {i}: {c.glyphName}": serialise_component(c)
             for i, c in enumerate(obj.components)
         }
-    elif obj.isVarComposite():
-        return {
-            f"Component {i}: {c.glyphName}": serialise_component(c)
-            for i, c in enumerate(obj.components)
-        }
     else:
         last = 0
         contours = {}


### PR DESCRIPTION
https://github.com/fonttools/fonttools/pull/3395 introduces the variable components table (VARC) and deprecates the glyph table's `isVarComposite` method.